### PR TITLE
wip:fix: included all accessed changed slots

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -223,6 +223,9 @@ impl GethTraceBuilder {
                 prestate.0.insert(addr, acc_state);
             }
 
+            // TODO check for accessed slots that are not part of the account diffs, for example
+            // handled reverted calls
+
             Ok(PreStateFrame::Default(prestate))
         } else {
             let mut state_diff = DiffMode::default();


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/8202

we need to manually track reverted changed slots in case they're handled gracefully