### PR TITLE
fix: use JsUint8Array for buffers

### DIFF
--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -1021,7 +1021,7 @@ mod tests {
             .unwrap();
         assert!(res.is_object());
 
-        let buf = from_buf_value(res.into(), &mut ctx).unwrap();
+        let buf = from_buf_value(res, &mut ctx).unwrap();
         assert_eq!(buf, contract.contract.as_slice());
 
         let call = eval_obj.as_object().unwrap().get(js_string!("value"), &mut ctx).unwrap();
@@ -1042,8 +1042,7 @@ mod tests {
             .call(&JsValue::undefined(), &[contract_arg], &mut ctx)
             .unwrap();
 
-        let array = JsUint8Array::from_object(res.as_object().unwrap().clone()).unwrap();
-        let buf = from_buf_value(array.into(), &mut ctx).unwrap();
+        let buf = from_buf_value(res, &mut ctx).unwrap();
         assert_eq!(buf, contract.input);
     }
 

--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -708,33 +708,23 @@ impl JsEvmContext {
             obj.set(js_string!("to"), JsValue::null(), false, ctx)?;
         }
 
-        obj.set(js_string!("input"), to_byte_array(input.to_vec(), ctx)?, false, ctx)?;
+        obj.set(js_string!("input"), to_byte_array(input, ctx)?, false, ctx)?;
         obj.set(js_string!("gas"), gas, false, ctx)?;
         obj.set(js_string!("gasUsed"), gas_used, false, ctx)?;
         obj.set(js_string!("gasPrice"), gas_price, false, ctx)?;
         obj.set(js_string!("intrinsicGas"), intrinsic_gas, false, ctx)?;
         obj.set(js_string!("value"), to_bigint(value, ctx)?, false, ctx)?;
         obj.set(js_string!("block"), block, false, ctx)?;
-        obj.set(js_string!("output"), to_byte_array(output.to_vec(), ctx)?, false, ctx)?;
+        obj.set(js_string!("output"), to_byte_array(output, ctx)?, false, ctx)?;
         obj.set(js_string!("time"), js_string!(time), false, ctx)?;
         if let Some(block_hash) = transaction_ctx.block_hash {
-            obj.set(
-                js_string!("blockHash"),
-                to_byte_array(block_hash.as_slice().to_vec(), ctx)?,
-                false,
-                ctx,
-            )?;
+            obj.set(js_string!("blockHash"), to_byte_array(block_hash.0, ctx)?, false, ctx)?;
         }
         if let Some(tx_index) = transaction_ctx.tx_index {
             obj.set(js_string!("txIndex"), tx_index as u64, false, ctx)?;
         }
         if let Some(tx_hash) = transaction_ctx.tx_hash {
-            obj.set(
-                js_string!("txHash"),
-                to_byte_array(tx_hash.as_slice().to_vec(), ctx)?,
-                false,
-                ctx,
-            )?;
+            obj.set(js_string!("txHash"), to_byte_array(tx_hash.0, ctx)?, false, ctx)?;
         }
 
         Ok(obj)

--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -3,8 +3,8 @@
 use crate::tracing::{
     js::{
         builtins::{
-            address_to_buf, bytes_to_address, bytes_to_hash, from_buf, to_bigint, to_buf,
-            to_buf_value,
+            address_to_byte_array, address_to_byte_array_value, bytes_to_address, bytes_to_hash,
+            from_buf_value, to_bigint, to_byte_array, to_byte_array_value,
         },
         TransactionContext,
     },
@@ -14,7 +14,7 @@ use alloy_primitives::{Address, Bytes, B256, U256};
 use boa_engine::{
     js_string,
     native_function::NativeFunction,
-    object::{builtins::JsArrayBuffer, FunctionObjectBuilder},
+    object::{builtins::JsUint8Array, FunctionObjectBuilder},
     Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsValue,
 };
 use boa_gc::{empty_trace, Finalize, Trace};
@@ -282,7 +282,7 @@ impl MemoryRef {
                         .with_inner(|mem| mem.slice(start, size).to_vec())
                         .unwrap_or_default();
 
-                    to_buf_value(slice, ctx)
+                    to_byte_array_value(slice, ctx)
                 },
                 self.clone(),
             ),
@@ -303,7 +303,7 @@ impl MemoryRef {
                          ));
                      }
                     let slice = memory.0.with_inner(|mem| mem.slice(offset, 32).to_vec()).unwrap_or_default();
-                     to_buf_value(slice, ctx)
+                     to_byte_array_value(slice, ctx)
                 },
                  self
             ),
@@ -512,7 +512,7 @@ impl Contract {
         let get_caller = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure(move |_this, _args, ctx| {
-                to_buf_value(caller.as_slice().to_vec(), ctx)
+                address_to_byte_array_value(caller, ctx)
             }),
         )
         .length(0)
@@ -521,7 +521,7 @@ impl Contract {
         let get_address = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure(move |_this, _args, ctx| {
-                to_buf_value(contract.as_slice().to_vec(), ctx)
+                address_to_byte_array_value(contract, ctx)
             }),
         )
         .length(0)
@@ -534,7 +534,7 @@ impl Contract {
         .length(0)
         .build();
 
-        let input = to_buf_value(input.to_vec(), ctx)?;
+        let input = to_byte_array_value(input, ctx)?;
         let get_input = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure_with_captures(
@@ -566,7 +566,7 @@ impl FrameResult {
         let Self { gas_used, output, error } = self;
         let obj = JsObject::default();
 
-        let output = to_buf_value(output.to_vec(), ctx)?;
+        let output = to_byte_array_value(output, ctx)?;
         let get_output = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure_with_captures(
@@ -604,7 +604,7 @@ impl CallFrame {
         let get_from = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure(move |_this, _args, ctx| {
-                to_buf_value(caller.as_slice().to_vec(), ctx)
+                address_to_byte_array_value(caller, ctx)
             }),
         )
         .length(0)
@@ -613,7 +613,7 @@ impl CallFrame {
         let get_to = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure(move |_this, _args, ctx| {
-                to_buf_value(contract.as_slice().to_vec(), ctx)
+                address_to_byte_array_value(contract, ctx)
             }),
         )
         .length(0)
@@ -626,7 +626,7 @@ impl CallFrame {
         .length(0)
         .build();
 
-        let input = to_buf_value(input.to_vec(), ctx)?;
+        let input = to_byte_array_value(input, ctx)?;
         let get_input = FunctionObjectBuilder::new(
             ctx.realm(),
             NativeFunction::from_copy_closure_with_captures(
@@ -701,26 +701,26 @@ impl JsEvmContext {
         // add properties
 
         obj.set(js_string!("type"), js_string!(r#type), false, ctx)?;
-        obj.set(js_string!("from"), address_to_buf(from, ctx)?, false, ctx)?;
+        obj.set(js_string!("from"), address_to_byte_array(from, ctx)?, false, ctx)?;
         if let Some(to) = to {
-            obj.set(js_string!("to"), address_to_buf(to, ctx)?, false, ctx)?;
+            obj.set(js_string!("to"), address_to_byte_array(to, ctx)?, false, ctx)?;
         } else {
             obj.set(js_string!("to"), JsValue::null(), false, ctx)?;
         }
 
-        obj.set(js_string!("input"), to_buf(input.to_vec(), ctx)?, false, ctx)?;
+        obj.set(js_string!("input"), to_byte_array(input.to_vec(), ctx)?, false, ctx)?;
         obj.set(js_string!("gas"), gas, false, ctx)?;
         obj.set(js_string!("gasUsed"), gas_used, false, ctx)?;
         obj.set(js_string!("gasPrice"), gas_price, false, ctx)?;
         obj.set(js_string!("intrinsicGas"), intrinsic_gas, false, ctx)?;
         obj.set(js_string!("value"), to_bigint(value, ctx)?, false, ctx)?;
         obj.set(js_string!("block"), block, false, ctx)?;
-        obj.set(js_string!("output"), to_buf(output.to_vec(), ctx)?, false, ctx)?;
+        obj.set(js_string!("output"), to_byte_array(output.to_vec(), ctx)?, false, ctx)?;
         obj.set(js_string!("time"), js_string!(time), false, ctx)?;
         if let Some(block_hash) = transaction_ctx.block_hash {
             obj.set(
                 js_string!("blockHash"),
-                to_buf(block_hash.as_slice().to_vec(), ctx)?,
+                to_byte_array(block_hash.as_slice().to_vec(), ctx)?,
                 false,
                 ctx,
             )?;
@@ -729,7 +729,12 @@ impl JsEvmContext {
             obj.set(js_string!("txIndex"), tx_index as u64, false, ctx)?;
         }
         if let Some(tx_hash) = transaction_ctx.tx_hash {
-            obj.set(js_string!("txHash"), to_buf(tx_hash.as_slice().to_vec(), ctx)?, false, ctx)?;
+            obj.set(
+                js_string!("txHash"),
+                to_byte_array(tx_hash.as_slice().to_vec(), ctx)?,
+                false,
+                ctx,
+            )?;
         }
 
         Ok(obj)
@@ -774,7 +779,7 @@ impl EvmDbRef {
     }
 
     fn read_basic(&self, address: JsValue, ctx: &mut Context) -> JsResult<Option<AccountInfo>> {
-        let buf = from_buf(address, ctx)?;
+        let buf = from_buf_value(address, ctx)?;
         let address = bytes_to_address(buf);
         if let acc @ Some(_) = self.inner.state.get_account(&address) {
             return Ok(acc);
@@ -790,11 +795,11 @@ impl EvmDbRef {
         }
     }
 
-    fn read_code(&self, address: JsValue, ctx: &mut Context) -> JsResult<JsArrayBuffer> {
+    fn read_code(&self, address: JsValue, ctx: &mut Context) -> JsResult<JsUint8Array> {
         let acc = self.read_basic(address, ctx)?;
         let code_hash = acc.map(|acc| acc.code_hash).unwrap_or(KECCAK_EMPTY);
         if code_hash == KECCAK_EMPTY {
-            return JsArrayBuffer::new(0, ctx);
+            return JsUint8Array::from_iter(std::iter::empty(), ctx);
         }
 
         let Some(Ok(bytecode)) = self.inner.db.0.with_inner(|db| db.code_by_hash_ref(code_hash))
@@ -805,7 +810,7 @@ impl EvmDbRef {
             ));
         };
 
-        to_buf(bytecode.bytecode().to_vec(), ctx)
+        to_byte_array(bytecode.bytecode().to_vec(), ctx)
     }
 
     fn read_state(
@@ -813,11 +818,11 @@ impl EvmDbRef {
         address: JsValue,
         slot: JsValue,
         ctx: &mut Context,
-    ) -> JsResult<JsArrayBuffer> {
-        let buf = from_buf(address, ctx)?;
+    ) -> JsResult<JsUint8Array> {
+        let buf = from_buf_value(address, ctx)?;
         let address = bytes_to_address(buf);
 
-        let buf = from_buf(slot, ctx)?;
+        let buf = from_buf_value(slot, ctx)?;
         let slot = bytes_to_hash(buf);
 
         let res = self.inner.db.0.with_inner(|db| db.storage_ref(address, slot.into()));
@@ -831,7 +836,7 @@ impl EvmDbRef {
             }
         };
         let value: B256 = value.into();
-        to_buf(value.as_slice().to_vec(), ctx)
+        to_byte_array(value.0, ctx)
     }
 
     pub(crate) fn into_js_object(self, ctx: &mut Context) -> JsResult<JsObject> {
@@ -1004,7 +1009,7 @@ mod tests {
             .unwrap();
         assert!(res.is_object());
         let obj = res.as_object().unwrap();
-        let array_buf = JsArrayBuffer::from_object(obj.clone());
+        let array_buf = JsUint8Array::from_object(obj.clone());
         assert!(array_buf.is_ok());
 
         let get_address =
@@ -1015,9 +1020,9 @@ mod tests {
             .call(&JsValue::undefined(), &[contract_arg.clone()], &mut ctx)
             .unwrap();
         assert!(res.is_object());
-        let obj = res.as_object().unwrap();
-        let array_buf = JsArrayBuffer::from_object(obj.clone()).unwrap();
-        assert_eq!(array_buf.data().unwrap().to_vec(), contract.contract.as_slice());
+
+        let buf = from_buf_value(res.into(), &mut ctx).unwrap();
+        assert_eq!(buf, contract.contract.as_slice());
 
         let call = eval_obj.as_object().unwrap().get(js_string!("value"), &mut ctx).unwrap();
         let res = call
@@ -1037,9 +1042,9 @@ mod tests {
             .call(&JsValue::undefined(), &[contract_arg], &mut ctx)
             .unwrap();
 
-        let buffer = JsArrayBuffer::from_object(res.as_object().unwrap().clone()).unwrap();
-        let input = buffer.data().unwrap().to_vec();
-        assert_eq!(input, contract.input);
+        let array = JsUint8Array::from_object(res.as_object().unwrap().clone()).unwrap();
+        let buf = from_buf_value(array.into(), &mut ctx).unwrap();
+        assert_eq!(buf, contract.input);
     }
 
     #[test]
@@ -1190,5 +1195,92 @@ mod tests {
         assert!(val.is_array());
         let s = val.to_string();
         assert_eq!(s, r#"[{"value":"35000"}]"#);
+    }
+
+    #[test]
+    fn test_object_functions() {
+        let mut context = Context::default();
+        register_builtins(&mut context).unwrap();
+
+        let eval = context
+            .eval(Source::from_bytes(
+                r#"(
+    {
+        retVal: [],
+        callStack: [],
+        byte2Hex: function (byte) {
+            if (byte < 0x10) return "0" + byte.toString(16);
+            return byte.toString(16);
+        },
+        array2Hex: function (arr) {
+            var retVal = "";
+            for (var i = 0; i < arr.length; i++) retVal += this.byte2Hex(arr[i]);
+            return retVal;
+        },
+        getAddr: function (log) {
+            return this.array2Hex(log.contract.getAddress());
+        },
+        step: function (log, db) {
+            var opcode = log.op.toNumber();
+            if (opcode == 0x54) {
+                this.retVal.push(this.getAddr(log) + ":" + log.stack.peek(0).toString(16));
+            }
+            if (opcode == 0x55)
+                this.retVal.push(
+                    this.getAddr(log) +
+                        ":" +
+                        log.stack.peek(0).toString(16) +
+                        ";" +
+                        log.stack.peek(1).toString(16)
+                );
+        },
+        fault: function (log, db) {
+            this.retVal.push("FAULT: ");
+        },
+        result: function (ctx, db) {
+            return this.retVal;
+        },
+   }
+)"#
+                .to_string()
+                .as_bytes(),
+            ))
+            .unwrap();
+
+        let obj = eval.as_object().unwrap();
+
+        let result_fn =
+            obj.get(js_string!("result"), &mut context).unwrap().as_object().cloned().unwrap();
+        let step_fn =
+            obj.get(js_string!("step"), &mut context).unwrap().as_object().cloned().unwrap();
+
+        let mut stack = Stack::new();
+        stack.push(U256::from(35000)).unwrap();
+        stack.push(U256::from(35000)).unwrap();
+        stack.push(U256::from(35000)).unwrap();
+        let (stack_ref, _stack_guard) = StackRef::new(&stack);
+        let mem = SharedMemory::new();
+        let (mem_ref, _mem_guard) = MemoryRef::new(&mem);
+
+        let step = StepLog {
+            stack: stack_ref,
+            op: OpObj(85),
+            memory: mem_ref,
+            pc: 0,
+            gas_remaining: 0,
+            cost: 0,
+            depth: 0,
+            refund: 0,
+            error: None,
+            contract: Default::default(),
+        };
+
+        let js_step = step.into_js_object(&mut context).unwrap();
+
+        let _ = step_fn.call(&eval, &[js_step.into()], &mut context).unwrap();
+
+        let res = result_fn.call(&eval, &[], &mut context).unwrap();
+        let val = json_stringify(res.clone(), &mut context).unwrap().to_std_string().unwrap();
+        assert_eq!(val, r#"["0000000000000000000000000000000000000000:88b8;88b8"]"#);
     }
 }

--- a/src/tracing/js/builtins.rs
+++ b/src/tracing/js/builtins.rs
@@ -2,9 +2,9 @@
 
 use alloy_primitives::{hex, Address, B256, U256};
 use boa_engine::{
-    builtins::array_buffer::ArrayBuffer,
+    builtins::{array_buffer::ArrayBuffer, typed_array::TypedArray},
     js_string,
-    object::builtins::{JsArray, JsArrayBuffer},
+    object::builtins::{JsArray, JsArrayBuffer, JsTypedArray, JsUint8Array},
     property::Attribute,
     Context, JsArgs, JsError, JsNativeError, JsResult, JsString, JsValue, NativeFunction, Source,
 };
@@ -89,9 +89,18 @@ pub(crate) fn register_builtins(ctx: &mut Context) -> JsResult<()> {
 }
 
 /// Converts an array, hex string or Uint8Array to a []byte
-pub(crate) fn from_buf(val: JsValue, context: &mut Context) -> JsResult<Vec<u8>> {
+pub(crate) fn from_buf_value(val: JsValue, context: &mut Context) -> JsResult<Vec<u8>> {
     if let Some(obj) = val.as_object().cloned() {
-        if obj.is::<ArrayBuffer>() {
+        if obj.is::<TypedArray>() {
+            let array: JsTypedArray = JsTypedArray::from_object(obj)?;
+            let len = array.length(context)?;
+            let mut buf = Vec::with_capacity(len);
+            for i in 0..len {
+                let val = array.get(i, context)?;
+                buf.push(val.to_number(context)? as u8);
+            }
+            return Ok(buf);
+        } else if obj.is::<ArrayBuffer>() {
             let buf = JsArrayBuffer::from_object(obj)?;
             let buf = buf.data().map(|data| data.to_vec()).ok_or_else(|| {
                 JsNativeError::typ().with_message("ArrayBuffer was already detached")
@@ -124,18 +133,35 @@ pub(crate) fn from_buf(val: JsValue, context: &mut Context) -> JsResult<Vec<u8>>
 }
 
 /// Create a new array buffer from the address' bytes.
-pub(crate) fn address_to_buf(addr: Address, context: &mut Context) -> JsResult<JsArrayBuffer> {
-    to_buf(addr.0.to_vec(), context)
+pub(crate) fn address_to_byte_array(
+    addr: Address,
+    context: &mut Context,
+) -> JsResult<JsUint8Array> {
+    JsUint8Array::from_iter(addr.0, context)
 }
 
-/// Create a new array buffer from byte block.
-pub(crate) fn to_buf(bytes: Vec<u8>, context: &mut Context) -> JsResult<JsArrayBuffer> {
-    JsArrayBuffer::from_byte_block(bytes, context)
+/// Create a new array buffer from the address' bytes.
+pub(crate) fn address_to_byte_array_value(
+    addr: Address,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    Ok(JsUint8Array::from_iter(addr.0, context)?.into())
+}
+
+/// Create a new array from byte block.
+pub(crate) fn to_byte_array<I>(bytes: I, context: &mut Context) -> JsResult<JsUint8Array>
+where
+    I: IntoIterator<Item = u8>,
+{
+    JsUint8Array::from_iter(bytes, context)
 }
 
 /// Create a new array buffer object from byte block.
-pub(crate) fn to_buf_value(bytes: Vec<u8>, context: &mut Context) -> JsResult<JsValue> {
-    Ok(to_buf(bytes, context)?.into())
+pub(crate) fn to_byte_array_value<I>(bytes: I, context: &mut Context) -> JsResult<JsValue>
+where
+    I: IntoIterator<Item = u8>,
+{
+    Ok(to_byte_array(bytes, context)?.into())
 }
 
 /// Converts a buffer type to an address.
@@ -204,17 +230,17 @@ pub(crate) fn to_contract2(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> 
     let initcode = args.get_or_undefined(2).clone();
 
     // Convert the sender's address to a byte buffer and then to an Address
-    let buf = from_buf(from, ctx)?;
+    let buf = from_buf_value(from, ctx)?;
     let addr = bytes_to_address(buf);
 
     // Convert the initcode to a byte buffer
-    let code_buf = from_buf(initcode, ctx)?;
+    let code_buf = from_buf_value(initcode, ctx)?;
 
     // Compute the contract address
     let contract_addr = addr.create2_from_code(salt, code_buf);
 
     // Convert the contract address to a byte buffer and return it as an ArrayBuffer
-    to_buf_value(contract_addr.0.to_vec(), ctx)
+    address_to_byte_array_value(contract_addr, ctx)
 }
 
 ///  Converts the sender's address to a byte buffer
@@ -224,36 +250,36 @@ pub(crate) fn to_contract(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> J
     let nonce = args.get_or_undefined(1).to_number(ctx)? as u64;
 
     // Convert the sender's address to a byte buffer and then to an Address
-    let buf = from_buf(from, ctx)?;
+    let buf = from_buf_value(from, ctx)?;
     let addr = bytes_to_address(buf);
 
     // Compute the contract address
     let contract_addr = addr.create(nonce);
 
     // Convert the contract address to a byte buffer and return it as an ArrayBuffer
-    to_buf_value(contract_addr.0.to_vec(), ctx)
+    address_to_byte_array_value(contract_addr, ctx)
 }
 
 /// Converts a buffer type to an address
 pub(crate) fn to_address(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
     let val = args.get_or_undefined(0).clone();
-    let buf = from_buf(val, ctx)?;
+    let buf = from_buf_value(val, ctx)?;
     let address = bytes_to_address(buf);
-    to_buf_value(address.0.to_vec(), ctx)
+    address_to_byte_array_value(address, ctx)
 }
 
 /// Converts a buffer type to a word
 pub(crate) fn to_word(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
     let val = args.get_or_undefined(0).clone();
-    let buf = from_buf(val, ctx)?;
+    let buf = from_buf_value(val, ctx)?;
     let hash = bytes_to_hash(buf);
-    to_buf_value(hash.0.to_vec(), ctx)
+    to_byte_array_value(hash.0, ctx)
 }
 
 /// Converts a buffer type to a hex string
 pub(crate) fn to_hex(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
     let val = args.get_or_undefined(0).clone();
-    let buf = from_buf(val, ctx)?;
+    let buf = from_buf_value(val, ctx)?;
     let s = js_string!(hex::encode(buf));
     Ok(JsValue::from(s))
 }
@@ -284,7 +310,7 @@ impl PrecompileList {
         let is_precompiled = NativeFunction::from_copy_closure_with_captures(
             move |_this, args, precompiles, ctx| {
                 let val = args.get_or_undefined(0).clone();
-                let buf = from_buf(val, ctx)?;
+                let buf = from_buf_value(val, ctx)?;
                 let addr = bytes_to_address(buf);
                 Ok(precompiles.0.contains(&addr).into())
             },

--- a/src/tracing/js/builtins.rs
+++ b/src/tracing/js/builtins.rs
@@ -132,7 +132,7 @@ pub(crate) fn from_buf_value(val: JsValue, context: &mut Context) -> JsResult<Ve
     ))
 }
 
-/// Create a new array buffer from the address' bytes.
+/// Create a new [JsUint8Array] array buffer from the address' bytes.
 pub(crate) fn address_to_byte_array(
     addr: Address,
     context: &mut Context,
@@ -140,7 +140,7 @@ pub(crate) fn address_to_byte_array(
     JsUint8Array::from_iter(addr.0, context)
 }
 
-/// Create a new array buffer from the address' bytes.
+/// Create a new [JsUint8Array] array buffer from the address' bytes.
 pub(crate) fn address_to_byte_array_value(
     addr: Address,
     context: &mut Context,
@@ -148,7 +148,7 @@ pub(crate) fn address_to_byte_array_value(
     Ok(JsUint8Array::from_iter(addr.0, context)?.into())
 }
 
-/// Create a new array from byte block.
+/// Create a new [JsUint8Array] from byte block.
 pub(crate) fn to_byte_array<I>(bytes: I, context: &mut Context) -> JsResult<JsUint8Array>
 where
     I: IntoIterator<Item = u8>,
@@ -156,7 +156,7 @@ where
     JsUint8Array::from_iter(bytes, context)
 }
 
-/// Create a new array buffer object from byte block.
+/// Create a new [JsUint8Array] object from byte block.
 pub(crate) fn to_byte_array_value<I>(bytes: I, context: &mut Context) -> JsResult<JsValue>
 where
     I: IntoIterator<Item = u8>,


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/8103

previously we were using the ArrayBuffer incorrectly, we need to use `JsUint8Array`

see also geth:

https://github.com/ethereum/go-ethereum/blob/473ee8fc07a3f89cf3978e164a6fad218de9a6b5/eth/tracers/js/goja.go#L575-L579
