### PR TITLE
feat: Add `Step` to `LogCallOrder`

### DIFF
--- a/src/tracing/arena.rs
+++ b/src/tracing/arena.rs
@@ -1,4 +1,4 @@
-use super::types::{CallTrace, CallTraceNode, LogCallOrder};
+use super::types::{CallTrace, CallTraceNode, TraceMemberOrder};
 
 /// An arena of recorded traces.
 ///
@@ -70,7 +70,7 @@ impl CallTraceArena {
                     if kind.is_attach_to_parent() {
                         let parent = &mut self.arena[entry];
                         let trace_location = parent.children.len();
-                        parent.ordering.push(LogCallOrder::Call(trace_location));
+                        parent.ordering.push(TraceMemberOrder::Call(trace_location));
                         parent.children.push(id);
                     }
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -2,7 +2,8 @@ use self::parity::stack_push_count;
 use crate::tracing::{
     arena::PushTraceKind,
     types::{
-        CallKind, CallTraceNode, TraceMemberOrder, RecordedMemory, StorageChange, StorageChangeReason,
+        CallKind, CallTraceNode, RecordedMemory, StorageChange, StorageChangeReason,
+        TraceMemberOrder,
     },
     utils::gas_used,
 };

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -332,7 +332,8 @@ impl TracingInspector {
         let trace_idx = self.last_trace_idx();
         let trace = &mut self.traces.arena[trace_idx];
 
-        self.step_stack.push(StackStep { trace_idx, step_idx: trace.trace.steps.len() });
+        let step_idx = trace.trace.steps.len();
+        self.step_stack.push(StackStep { trace_idx, step_idx });
 
         let memory = self
             .config
@@ -366,6 +367,8 @@ impl TracingInspector {
             storage_change: None,
             status: InstructionResult::Continue,
         });
+
+        trace.ordering.push(LogCallOrder::Step(step_idx));
     }
 
     /// Fills the current trace with the output of a step.

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -2,7 +2,7 @@ use self::parity::stack_push_count;
 use crate::tracing::{
     arena::PushTraceKind,
     types::{
-        CallKind, CallTraceNode, LogCallOrder, RecordedMemory, StorageChange, StorageChangeReason,
+        CallKind, CallTraceNode, TraceMemberOrder, RecordedMemory, StorageChange, StorageChangeReason,
     },
     utils::gas_used,
 };
@@ -368,7 +368,7 @@ impl TracingInspector {
             status: InstructionResult::Continue,
         });
 
-        trace.ordering.push(LogCallOrder::Step(step_idx));
+        trace.ordering.push(TraceMemberOrder::Step(step_idx));
     }
 
     /// Fills the current trace with the output of a step.
@@ -459,7 +459,7 @@ where
     fn log(&mut self, _context: &mut EvmContext<DB>, log: &Log) {
         if self.config.record_logs {
             let trace = self.last_trace();
-            trace.ordering.push(LogCallOrder::Log(trace.logs.len()));
+            trace.ordering.push(TraceMemberOrder::Log(trace.logs.len()));
             trace.logs.push(log.data.clone());
         }
     }

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -129,7 +129,7 @@ pub struct CallTraceNode {
     /// Recorded logs, if enabled
     pub logs: Vec<LogData>,
     /// Ordering of child calls and logs
-    pub ordering: Vec<LogCallOrder>,
+    pub ordering: Vec<TraceMemberOrder>,
 }
 
 impl CallTraceNode {
@@ -470,10 +470,10 @@ pub(crate) struct CallTraceStepStackItem<'a> {
     pub(crate) call_child_id: Option<usize>,
 }
 
-/// Ordering enum for calls and logs
+/// Ordering enum for calls, logs and steps
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub enum LogCallOrder {
+pub enum TraceMemberOrder {
     /// Contains the index of the corresponding log
     Log(usize),
     /// Contains the index of the corresponding trace node

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -478,6 +478,8 @@ pub enum LogCallOrder {
     Log(usize),
     /// Contains the index of the corresponding trace node
     Call(usize),
+    /// Contains the index of the corresponding step, if those are being traced
+    Step(usize),
 }
 
 /// Represents a tracked call step during execution

--- a/src/tracing/writer.rs
+++ b/src/tracing/writer.rs
@@ -1,5 +1,5 @@
 use super::{
-    types::{CallKind, CallTrace, CallTraceNode, LogCallOrder},
+    types::{CallKind, CallTrace, CallTraceNode, TraceMemberOrder},
     CallTraceArena,
 };
 use alloy_primitives::{address, hex, Address, LogData};
@@ -98,9 +98,9 @@ impl<W: Write> TraceWriter<W> {
         self.indentation_level += 1;
         for child in &node.ordering {
             match *child {
-                LogCallOrder::Log(index) => self.write_raw_log(&node.logs[index]),
-                LogCallOrder::Call(index) => self.write_node(nodes, node.children[index]),
-                LogCallOrder::Step(_) => Ok(()),
+                TraceMemberOrder::Log(index) => self.write_raw_log(&node.logs[index]),
+                TraceMemberOrder::Call(index) => self.write_node(nodes, node.children[index]),
+                TraceMemberOrder::Step(_) => Ok(()),
             }?;
         }
 

--- a/src/tracing/writer.rs
+++ b/src/tracing/writer.rs
@@ -100,6 +100,7 @@ impl<W: Write> TraceWriter<W> {
             match *child {
                 LogCallOrder::Log(index) => self.write_raw_log(&node.logs[index]),
                 LogCallOrder::Call(index) => self.write_node(nodes, node.children[index]),
+                LogCallOrder::Step(_) => Ok(()),
             }?;
         }
 


### PR DESCRIPTION
Adds `Step` variant for `LogCallOrder` enum and renames it to `TraceMemberOrder`.

This is useful for printing logic which relies on execution steps as well, e.g. https://github.com/foundry-rs/foundry/pull/8222