### PR TITLE
feat: small updates for steps tracing

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -9,15 +9,24 @@ use std::collections::HashSet;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct OpcodeFilter([bool; 256]);
 
+impl Default for OpcodeFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OpcodeFilter {
+    /// Returns a new [OpcodeFilter] that does not trace any opcodes.
     pub const fn new() -> Self {
         Self([false; 256])
     }
 
+    /// Returns whether steps with given [OpCode] should be traced.
     pub fn enabled(&self, op: &OpCode) -> bool {
         self.0[op.get() as usize]
     }
 
+    /// Enables tracing of given [OpCode].
     pub const fn enable(mut self, op: OpCode) -> Self {
         self.0[op.get() as usize] = true;
         self

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -28,6 +28,7 @@ impl OpcodeFilter {
     }
 
     /// Enables tracing of given [OpCode].
+    #[must_use]
     pub const fn enable(self, op: OpCode) -> Self {
         let bit = op.get() as usize;
 

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -281,6 +281,12 @@ impl TracingInspectorConfig {
         self.record_logs = record_logs;
         self
     }
+
+    /// If [OpcodeFilter] is configured, returns whether the given opcode should be recorded.
+    /// Otherwise, always returns true.
+    pub fn should_record_opcode(&self, op: &OpCode) -> bool {
+        self.record_opcodes_filter.map_or(true, |filter| filter.is_enabled(op))
+    }
 }
 
 /// How much of the stack to record. Nothing, just the items pushed, or the full stack

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -338,7 +338,7 @@ impl TracingInspector {
         // that not a known constant
         let op = unsafe { OpCode::new_unchecked(interp.current_opcode()) };
 
-        let record = self.config.record_opcodes_filter.as_ref().map_or(true, |f| f.is_enabled(&op));
+        let record = self.config.should_record_opcode(&op);
 
         self.step_stack.push(StackStep { trace_idx, step_idx, record });
 
@@ -582,9 +582,19 @@ where
     }
 }
 
+/// Struct keeping track of internal inspector steps stack.
 #[derive(Clone, Copy, Debug)]
 struct StackStep {
-    trace_idx: usize,
-    step_idx: usize,
+    /// Whether this step should be recorded.
+    ///
+    /// This is set to `false` if [OpcodeFilter] is configured and this step's opcode is not
+    /// enabled for tracking
     record: bool,
+    /// Idx of the trace node this step belongs.
+    trace_idx: usize,
+    /// Idx of this step in the [CallTrace::steps].
+    ///
+    /// Please note that if `record` is `false`, this will still contain a value, but the step will
+    /// not appear in the steps list.
+    step_idx: usize,
 }

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -338,8 +338,7 @@ impl TracingInspector {
         // that not a known constant
         let op = unsafe { OpCode::new_unchecked(interp.current_opcode()) };
 
-        let record =
-            self.config.record_opcodes_filter.as_ref().map(|f| f.enabled(&op)).unwrap_or(true);
+        let record = self.config.record_opcodes_filter.as_ref().map_or(true, |f| f.enabled(&op));
 
         self.step_stack.push(StackStep { trace_idx, step_idx, record });
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -27,7 +27,7 @@ pub use builder::{
 };
 
 mod config;
-pub use config::{StackSnapshotType, TracingInspectorConfig};
+pub use config::{OpcodeFilter, StackSnapshotType, TracingInspectorConfig};
 
 mod fourbyte;
 pub use fourbyte::FourByteInspector;

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -338,7 +338,7 @@ impl TracingInspector {
         // that not a known constant
         let op = unsafe { OpCode::new_unchecked(interp.current_opcode()) };
 
-        let record = self.config.record_opcodes_filter.as_ref().map_or(true, |f| f.enabled(&op));
+        let record = self.config.record_opcodes_filter.as_ref().map_or(true, |f| f.is_enabled(&op));
 
         self.step_stack.push(StackStep { trace_idx, step_idx, record });
 

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -506,10 +506,14 @@ pub struct CallTraceStep {
     pub memory: RecordedMemory,
     /// Size of memory at the beginning of the step
     pub memory_size: usize,
+    /// Returndata before step execution
+    pub returndata: Bytes,
     /// Remaining gas before step execution
     pub gas_remaining: u64,
     /// Gas refund counter before step execution
     pub gas_refund_counter: u64,
+    /// Total gas used before step execution
+    pub gas_used: u64,
     // Fields filled in `step_end`
     /// Gas cost of step execution
     pub gas_cost: u64,


### PR DESCRIPTION
- Adds `record_returndata_snapshots` flag to config which enables snapshots of `interpreter.return_data_buffer`
- Adds `record_opcodes_filter` parameter which allows to only record specific opcodes. ref https://github.com/foundry-rs/foundry/pull/8222#issuecomment-2186811858
- Adds `gas_used` field for `CallTraceStep`

This should be enough to migrate foundry's debugger to using `TracingInspector` from here, I will open PR for this later today.