### PR TITLE
fix: track selfdestruct transferred value separately

### DIFF
--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -578,7 +578,7 @@ where
         let node = self.last_trace();
         node.trace.address = contract;
         node.trace.selfdestruct_refund_target = Some(target);
-        node.trace.value = value;
+        node.trace.selfdestruct_transferred_value = Some(value);
     }
 }
 

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -41,6 +41,13 @@ pub struct CallTrace {
     ///
     /// See [`is_selfdestruct`](Self::is_selfdestruct) for more information.
     pub selfdestruct_refund_target: Option<Address>,
+    /// The value transferred on a selfdestruct.
+    ///
+    /// This is only `Some` if a selfdestruct was executed and the call is executed before the
+    /// Cancun hardfork.
+    ///
+    /// See [`is_selfdestruct`](Self::is_selfdestruct) for more information.
+    pub selfdestruct_transferred_value: Option<U256>,
     /// The kind of call.
     pub kind: CallKind,
     /// The value transferred in the call.
@@ -240,7 +247,7 @@ impl CallTraceNode {
             Some(Action::Selfdestruct(SelfdestructAction {
                 address: self.trace.address,
                 refund_address: self.trace.selfdestruct_refund_target.unwrap_or_default(),
-                balance: self.trace.value,
+                balance: self.trace.selfdestruct_transferred_value.unwrap_or_default(),
             }))
         } else {
             None
@@ -254,7 +261,7 @@ impl CallTraceNode {
                 typ: "SELFDESTRUCT".to_string(),
                 from: self.trace.caller,
                 to: self.trace.selfdestruct_refund_target,
-                value: Some(self.trace.value),
+                value: self.trace.selfdestruct_transferred_value,
                 ..Default::default()
             })
         } else {


### PR DESCRIPTION
in https://github.com/paradigmxyz/revm-inspectors/commit/ee6f6be412c61a494472468c37bc7b8bc292b458 we updated

`node.trace.value = value;` with the selfdestruct value transfer.

this results in incorrect traces for original call: https://github.com/paradigmxyz/reth/issues/9124


This tracks the transferred value in a separate field similar to refund address.

