### PR TITLE
feat: add immediate bytes recording

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -72,6 +72,8 @@ pub struct TracingInspectorConfig {
     pub exclude_precompile_calls: bool,
     /// Whether to record logs
     pub record_logs: bool,
+    /// Whether to record immediate bytes for opcodes.
+    pub record_immediate_bytes: bool,
 }
 
 impl TracingInspectorConfig {
@@ -86,6 +88,7 @@ impl TracingInspectorConfig {
             record_opcodes_filter: None,
             exclude_precompile_calls: false,
             record_logs: true,
+            record_immediate_bytes: true,
         }
     }
 
@@ -100,6 +103,7 @@ impl TracingInspectorConfig {
             exclude_precompile_calls: false,
             record_logs: false,
             record_opcodes_filter: None,
+            record_immediate_bytes: false,
         }
     }
 
@@ -116,6 +120,7 @@ impl TracingInspectorConfig {
             exclude_precompile_calls: true,
             record_logs: false,
             record_opcodes_filter: None,
+            record_immediate_bytes: false,
         }
     }
 
@@ -135,6 +140,7 @@ impl TracingInspectorConfig {
             exclude_precompile_calls: false,
             record_logs: false,
             record_opcodes_filter: None,
+            record_immediate_bytes: false,
         }
     }
 
@@ -290,6 +296,17 @@ impl TracingInspectorConfig {
     pub const fn set_record_logs(mut self, record_logs: bool) -> Self {
         self.record_logs = record_logs;
         self
+    }
+
+    /// Configure whether the tracer should record immediate bytes
+    pub const fn set_immediate_bytes(mut self, record_immediate_bytes: bool) -> Self {
+        self.record_immediate_bytes = record_immediate_bytes;
+        self
+    }
+
+    /// Enable recording of immediate bytes
+    pub const fn record_immediate_bytes(self) -> Self {
+        self.set_immediate_bytes(true)
     }
 
     /// If [OpcodeFilter] is configured, returns whether the given opcode should be recorded.

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -417,6 +417,7 @@ impl TracingInspector {
         trace.trace.steps.push(CallTraceStep {
             depth: context.journaled_state.depth(),
             pc: interp.program_counter(),
+            code_section_idx: interp.function_stack.current_code_idx,
             op,
             contract: interp.contract.target_address,
             stack,

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -400,6 +400,15 @@ impl TracingInspector {
         let gas_used =
             gas_used(context.spec_id(), interp.gas.spent(), interp.gas.refunded() as u64);
 
+        let immediate_bytes = self.config.record_immediate_bytes.then(|| {
+            let pc = interp.program_counter();
+            interp
+                .bytecode
+                .get(pc + 1..pc + 1 + op.info().immediate_size() as usize)
+                .map(Bytes::copy_from_slice)
+                .unwrap_or_default()
+        });
+
         trace.trace.steps.push(CallTraceStep {
             depth: context.journaled_state.depth(),
             pc: interp.program_counter(),
@@ -413,6 +422,7 @@ impl TracingInspector {
             gas_refund_counter: interp.gas.refunded() as u64,
             gas_used,
             decoded: None,
+            immediate_bytes,
 
             // fields will be populated end of call
             gas_cost: 0,

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -400,14 +400,15 @@ impl TracingInspector {
         let gas_used =
             gas_used(context.spec_id(), interp.gas.spent(), interp.gas.refunded() as u64);
 
-        let immediate_bytes = self.config.record_immediate_bytes.then(|| {
-            let pc = interp.program_counter();
-            interp
-                .bytecode
-                .get(pc + 1..pc + 1 + op.info().immediate_size() as usize)
-                .map(Bytes::copy_from_slice)
-                .unwrap_or_default()
-        });
+        let immediate_bytes =
+            (self.config.record_immediate_bytes && op.info().immediate_size() > 0).then(|| {
+                let pc = interp.program_counter();
+                interp
+                    .bytecode
+                    .get(pc + 1..pc + 1 + op.info().immediate_size() as usize)
+                    .map(Bytes::copy_from_slice)
+                    .unwrap_or_default()
+            });
 
         trace.trace.steps.push(CallTraceStep {
             depth: context.journaled_state.depth(),

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -581,6 +581,8 @@ pub struct CallTraceStep {
     pub depth: u64,
     /// Program counter before step execution
     pub pc: usize,
+    /// Code section index before step execution
+    pub code_section_idx: usize,
     /// Opcode to be executed
     #[cfg_attr(feature = "serde", serde(with = "opcode_serde"))]
     pub op: OpCode,

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -611,6 +611,8 @@ pub struct CallTraceStep {
     ///
     /// This is set after the step was executed.
     pub status: InstructionResult,
+    /// Immediate bytes of the step
+    pub immediate_bytes: Option<Bytes>,
     /// Optional complementary decoded step data.
     pub decoded: Option<DecodedTraceStep>,
 }


### PR DESCRIPTION
before EOF those were only present for `PUSH*` opcodes, and they were trivial to obtain by looking at the top of the stack, now it is a bit more complex, so this would be useful