### PR TITLE
Fix Self-destruct Disorder

### DIFF
--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -255,6 +255,8 @@ impl ParityTraceBuilder {
             }
         }
 
+        traces.sort_by(|a, b| a.trace_address.cmp(&b.trace_address));
+
         let traces = with_traces.then_some(traces);
         let diff = with_diff.then_some(StateDiff::default());
 


### PR DESCRIPTION
The `suicide`/`selfdestruct` trace should not be immediately after the parent trace but after all of the parent's subtraces.

This can be fixed by ordering the `traces` using the attribute `trace_address` inside.

closes https://github.com/paradigmxyz/revm-inspectors/issues/162