### PR TITLE
feat(tracing): add `unmatched` parameter to `CallLog`

### DIFF
--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -156,6 +156,17 @@ pub struct DecodedCallLog {
     pub params: Option<Vec<(String, String)>>,
 }
 
+/// portable representation of call Log Styling
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum LogStyle {
+    /// The style when no special highlighting is needed
+    #[default]
+    Default,
+    /// The style when a log should be colored to denote an error
+    Error,
+}
+
 /// A log with optional decoded data.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -164,8 +175,9 @@ pub struct CallLog {
     pub raw_log: LogData,
     /// Optional complementary decoded log data.
     pub decoded: DecodedCallLog,
-    /// A bool to render unmatched logs as errors from forge tests
-    pub unmatched: bool,
+    /// A style config that allows for setting styles or error
+    /// state externally
+    pub style: LogStyle,
 }
 
 impl From<Log> for CallLog {
@@ -174,7 +186,7 @@ impl From<Log> for CallLog {
         Self {
             raw_log: log.data,
             decoded: DecodedCallLog { name: None, params: None },
-            unmatched: false,
+            style: LogStyle::default(),
         }
     }
 }

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -164,12 +164,18 @@ pub struct CallLog {
     pub raw_log: LogData,
     /// Optional complementary decoded log data.
     pub decoded: DecodedCallLog,
+    /// A bool to render unmatched logs as errors from forge tests
+    pub unmatched: bool,
 }
 
 impl From<Log> for CallLog {
     /// Converts a [`Log`] into a [`CallLog`].
     fn from(log: Log) -> Self {
-        Self { raw_log: log.data, decoded: DecodedCallLog { name: None, params: None } }
+        Self {
+            raw_log: log.data,
+            decoded: DecodedCallLog { name: None, params: None },
+            unmatched: false,
+        }
     }
 }
 

--- a/src/tracing/writer.rs
+++ b/src/tracing/writer.rs
@@ -1,7 +1,6 @@
 use super::{
     types::{
-        CallKind, CallLog, CallTrace, CallTraceNode, DecodedCallData, DecodedTraceStep,
-        TraceMemberOrder,
+        CallKind, CallLog, CallTrace, CallTraceNode, DecodedCallData, DecodedTraceStep, LogStyle, TraceMemberOrder
     },
     CallTraceArena,
 };
@@ -395,9 +394,9 @@ impl<W: Write> TraceWriter<W> {
         if !self.use_colors {
             return Style::default();
         }
-        match log.unmatched {
-            true => AnsiColor::Red.on_default(),
-            false => LOG_STYLE,
+        match log.style {
+            LogStyle::Error => AnsiColor::Red.on_default(),
+            LogStyle::Default => Style::default(),
         }
     }
 


### PR DESCRIPTION
This allows for the rendering of unmatched logs as errors in traces
as discussed in foundry-rs/foundry#8506
