### PR TITLE
Use `code` from `AccountInfo` if it is `Some`

### DIFF
--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -454,7 +454,8 @@ where
         curr_ref.code = if let Some(code) = db_acc.code {
             code.original_bytes()
         } else {
-            let code_hash = if db_acc.code_hash != KECCAK_EMPTY { db_acc.code_hash } else { continue };
+            let code_hash =
+                if db_acc.code_hash != KECCAK_EMPTY { db_acc.code_hash } else { continue };
 
             db.code_by_hash_ref(code_hash)?.original_bytes()
         };


### PR DESCRIPTION
If the `code` in an `AccountInfo` is already `Some`, it is unnecessary to fetch the code again using `code_by_hash_ref`.