### PR TITLE
feat(tracing/builder): optimize the trace builder

### DIFF
--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -252,7 +252,7 @@ impl ParityTraceBuilder {
 
             // Sort the traces only if a selfdestruct trace was encountered
             if sorting_selfdestruct {
-                traces.sort_by(|a, b| a.trace_address.cmp(&b.trace_address));
+                traces.sort_unstable_by(|a, b| a.trace_address.cmp(&b.trace_address));
             }
             traces
         });

--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -212,33 +212,33 @@ impl ParityTraceBuilder {
             return (None, None, None);
         }
 
-        let with_traces = trace_types.contains(&TraceType::Trace);
         let with_diff = trace_types.contains(&TraceType::StateDiff);
 
-        let vm_trace =
-            if trace_types.contains(&TraceType::VmTrace) { Some(self.vm_trace()) } else { None };
+        // early return for StateDiff-only case
+        if trace_types.len() == 1 && with_diff {
+            return (None, None, Some(StateDiff::default()));
+        }
 
-        let mut traces = Vec::with_capacity(if with_traces { self.nodes.len() } else { 0 });
-        // Boolean marker to track if sorting for selfdestruct is needed
-        let mut sorting_selfdestruct = false;
+        let vm_trace = trace_types.contains(&TraceType::VmTrace).then(|| self.vm_trace());
 
-        for node in self.iter_traceable_nodes() {
-            let trace_address = self.trace_address(node.idx);
+        let traces = trace_types.contains(&TraceType::Trace).then(|| {
+            let mut traces = Vec::with_capacity(self.nodes.len());
+            let mut sorting_selfdestruct = false;
 
-            if with_traces {
+            for node in self.iter_traceable_nodes() {
+                let trace_address = self.trace_address(node.idx);
                 let trace = node.parity_transaction_trace(trace_address);
                 traces.push(trace);
 
-                // check if the trace node is a selfdestruct
                 if node.is_selfdestruct() {
                     // selfdestructs are not recorded as individual call traces but are derived from
                     // the call trace and are added as additional `TransactionTrace` objects in the
                     // trace array
                     let addr = {
                         let last = traces.last_mut().expect("exists");
-                        let mut addr = last.trace_address.clone();
+                        let mut addr = Vec::with_capacity(last.trace_address.len() + 1);
+                        addr.extend_from_slice(&last.trace_address);
                         addr.push(last.subtraces);
-                        // need to account for the additional selfdestruct trace
                         last.subtraces += 1;
                         addr
                     };
@@ -249,15 +249,15 @@ impl ParityTraceBuilder {
                     }
                 }
             }
-        }
 
-        // Sort the traces only if a selfdestruct trace was encountered
-        if sorting_selfdestruct {
-            traces.sort_by(|a, b| a.trace_address.cmp(&b.trace_address));
-        }
+            // Sort the traces only if a selfdestruct trace was encountered
+            if sorting_selfdestruct {
+                traces.sort_by(|a, b| a.trace_address.cmp(&b.trace_address));
+            }
+            traces
+        });
 
-        let traces = with_traces.then_some(traces);
-        let diff = with_diff.then_some(StateDiff::default());
+        let diff = with_diff.then(StateDiff::default);
 
         (traces, vm_trace, diff)
     }

--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -223,6 +223,7 @@ impl ParityTraceBuilder {
 
         let traces = trace_types.contains(&TraceType::Trace).then(|| {
             let mut traces = Vec::with_capacity(self.nodes.len());
+            // Boolean marker to track if sorting for selfdestruct is needed
             let mut sorting_selfdestruct = false;
 
             for node in self.iter_traceable_nodes() {

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -317,16 +317,18 @@ impl CallTraceNode {
 
     /// If the trace is a selfdestruct, returns the `Action` for a parity trace.
     pub fn parity_selfdestruct_action(&self) -> Option<Action> {
-        self.is_selfdestruct().then_some(Action::Selfdestruct(SelfdestructAction {
-            address: self.trace.address,
-            refund_address: self.trace.selfdestruct_refund_target.unwrap_or_default(),
-            balance: self.trace.selfdestruct_transferred_value.unwrap_or_default(),
-        }))
+        self.is_selfdestruct().then(|| {
+            Action::Selfdestruct(SelfdestructAction {
+                address: self.trace.address,
+                refund_address: self.trace.selfdestruct_refund_target.unwrap_or_default(),
+                balance: self.trace.selfdestruct_transferred_value.unwrap_or_default(),
+            })
+        })
     }
 
     /// If the trace is a selfdestruct, returns the `CallFrame` for a geth call trace
     pub fn geth_selfdestruct_call_trace(&self) -> Option<CallFrame> {
-        self.is_selfdestruct().then_some(CallFrame {
+        self.is_selfdestruct().then(|| CallFrame {
             typ: "SELFDESTRUCT".to_string(),
             from: self.trace.address,
             to: self.trace.selfdestruct_refund_target,

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -270,11 +270,7 @@ impl CallTraceNode {
 
     /// Returns the call context's 4 byte selector
     pub fn selector(&self) -> Option<FixedBytes<4>> {
-        if self.trace.data.len() < 4 {
-            None
-        } else {
-            Some(FixedBytes::from_slice(&self.trace.data[..4]))
-        }
+        (self.trace.data.len() >= 4).then_some(|| FixedBytes::from_slice(&self.trace.data[..4]))
     }
 
     /// Returns `true` if this trace was a selfdestruct.
@@ -321,30 +317,22 @@ impl CallTraceNode {
 
     /// If the trace is a selfdestruct, returns the `Action` for a parity trace.
     pub fn parity_selfdestruct_action(&self) -> Option<Action> {
-        if self.is_selfdestruct() {
-            Some(Action::Selfdestruct(SelfdestructAction {
-                address: self.trace.address,
-                refund_address: self.trace.selfdestruct_refund_target.unwrap_or_default(),
-                balance: self.trace.selfdestruct_transferred_value.unwrap_or_default(),
-            }))
-        } else {
-            None
-        }
+        self.is_selfdestruct().then_some(Action::Selfdestruct(SelfdestructAction {
+            address: self.trace.address,
+            refund_address: self.trace.selfdestruct_refund_target.unwrap_or_default(),
+            balance: self.trace.selfdestruct_transferred_value.unwrap_or_default(),
+        }))
     }
 
     /// If the trace is a selfdestruct, returns the `CallFrame` for a geth call trace
     pub fn geth_selfdestruct_call_trace(&self) -> Option<CallFrame> {
-        if self.is_selfdestruct() {
-            Some(CallFrame {
-                typ: "SELFDESTRUCT".to_string(),
-                from: self.trace.address,
-                to: self.trace.selfdestruct_refund_target,
-                value: self.trace.selfdestruct_transferred_value,
-                ..Default::default()
-            })
-        } else {
-            None
-        }
+        self.is_selfdestruct().then_some(CallFrame {
+            typ: "SELFDESTRUCT".to_string(),
+            from: self.trace.address,
+            to: self.trace.selfdestruct_refund_target,
+            value: self.trace.selfdestruct_transferred_value,
+            ..Default::default()
+        })
     }
 
     /// If the trace is a selfdestruct, returns the `TransactionTrace` for a parity trace.

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -270,7 +270,7 @@ impl CallTraceNode {
 
     /// Returns the call context's 4 byte selector
     pub fn selector(&self) -> Option<FixedBytes<4>> {
-        (self.trace.data.len() >= 4).then_some(|| FixedBytes::from_slice(&self.trace.data[..4]))
+        (self.trace.data.len() >= 4).then(|| FixedBytes::from_slice(&self.trace.data[..4]))
     }
 
     /// Returns `true` if this trace was a selfdestruct.


### PR DESCRIPTION
Some small optimizes:

- early return for StateDiff-only requests
- early check `if with_traces` instead of inside the for-loop
- for trace address use `Vec::with_capacity(n+1)` instead of `clone`