### PR TITLE
fix(tracing/builder): ensure the selfdestruct trace is at the ending of the same depth

### DIFF
--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -411,15 +411,15 @@ where
     type Item = TransactionTrace;
 
     fn next(&mut self) -> Option<Self::Item> {
+        // ensure the selfdestruct trace is emitted just at the ending of the same depth
         if let Some(selfdestruct) = &self.next_selfdestruct {
-            if let Some((next_trace, _)) = self.iter.peek() {
-                if selfdestruct.trace_address < next_trace.trace_address {
-                    return self.next_selfdestruct.take();
-                }
-            } else {
+            if self.iter.peek().map_or(true, |(next_trace, _)| {
+                selfdestruct.trace_address < next_trace.trace_address
+            }) {
                 return self.next_selfdestruct.take();
             }
         }
+
         let (mut trace, node) = self.iter.next()?;
         if node.is_selfdestruct() {
             // since selfdestructs are emitted as additional trace, increase the trace count

--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -559,3 +559,30 @@ where
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tracing::types::{CallKind, CallTrace};
+
+    #[test]
+    fn test_parity_suicide_simple_call() {
+        let nodes = vec![CallTraceNode {
+            trace: CallTrace {
+                kind: CallKind::Call,
+                selfdestruct_refund_target: Some(Address::ZERO),
+                ..Default::default()
+            },
+            ..Default::default()
+        }];
+
+        let traces = ParityTraceBuilder::new(nodes, None, TracingInspectorConfig::default_parity())
+            .into_transaction_traces();
+
+        assert_eq!(traces.len(), 2);
+        assert_eq!(traces[0].trace_address.len(), 0);
+        assert!(traces[0].action.is_call());
+        assert_eq!(traces[1].trace_address, vec![0]);
+        assert!(traces[1].action.is_selfdestruct());
+    }
+}


### PR DESCRIPTION
because the selfdestruct doesn't have separate trace, if will returned just after the original call, this is inaccure, and we should keep them staying at the ending of the same call depth.