### PR TITLE
fix(tracing): align trace output with geth

### DIFF
--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -346,7 +346,8 @@ impl TracingInspector {
         let trace_idx = self.pop_trace_idx();
         let trace = &mut self.traces.arena[trace_idx].trace;
 
-        trace.gas_used = gas.spent();
+        trace.gas_used =
+            if result.is_ok() || result.is_revert() { gas.spent() } else { gas.remaining() };
 
         trace.status = result;
         trace.success = trace.status.is_ok();

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -140,6 +140,9 @@ impl CallTrace {
             InstructionResult::PrecompileError => {
                 if kind.is_parity() { "Built-in failed" } else { "precompiled failed" }.to_string()
             }
+            InstructionResult::InvalidFEOpcode => {
+                if kind.is_parity() { "Bad instruction: INVALID" } else { "invalid opcode: INVALID" }.to_string()
+            }
             status => format!("{:?}", status),
         })
     }
@@ -403,9 +406,7 @@ impl CallTraceNode {
         // we need to populate error and revert reason
         if !self.trace.success {
             call_frame.revert_reason = utils::maybe_revert_reason(self.trace.output.as_ref());
-
-            // Note: the call tracer mimics parity's trace transaction and geth maps errors to parity style error messages, <https://github.com/ethereum/go-ethereum/blob/34d507215951fb3f4a5983b65e127577989a6db8/eth/tracers/native/call_flat.go#L39-L55>
-            call_frame.error = self.trace.as_error_msg(TraceStyle::Parity);
+            call_frame.error = self.trace.as_error_msg(TraceStyle::Geth);
         }
 
         if include_logs && !self.logs.is_empty() {


### PR DESCRIPTION
1. The error msg should not be converted to parity style in `callTracer`. They should only be converted in `flatCallTracer` which is not supported by reth now.
2. The `gasUsed` should be the `gasLimit` when there's a not reverted error.

Related geth code: 
* https://github.com/ethereum/go-ethereum/blob/a9523b6428238a762e1a1e55e46ead47630c3a23/eth/tracers/native/call_flat.go#L226
* https://github.com/ethereum/go-ethereum/blob/a9523b6428238a762e1a1e55e46ead47630c3a23/core/vm/evm.go#L254