### PR TITLE
chore: add `from_flat_call_config`

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -400,4 +400,14 @@ mod tests {
         // not required for StateDiff
         assert!(!config.record_state_diff);
     }
+
+    fn test_flat_call_config() {
+        let config = FlatCallConfig { include_precompiles: Some(true), ..Default::default() };
+        let config = TracingInspectorConfig::from_flat_call_config(&config);
+        assert!(!config.exclude_precompile_calls);
+
+        let config = FlatCallConfig { include_precompiles: Some(false), ..Default::default() };
+        let config = TracingInspectorConfig::from_flat_call_config(&config);
+        assert!(config.exclude_precompile_calls);
+    }
 }

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -188,10 +188,12 @@ impl TracingInspectorConfig {
             .set_record_logs(config.with_log.unwrap_or_default())
     }
 
-    /// Returns a config for geth's [FlatCallTracer](alloy_rpc_types_trace::geth::call::FlatCallFrame).
+    /// Returns a config for geth's
+    /// [FlatCallTracer](alloy_rpc_types_trace::geth::call::FlatCallFrame).
     ///
-    /// This returns [Self::default_parity] and sets [TracingInspectorConfig::exclude_precompile_calls]
-    /// if configured in the given [FlatCallConfig]
+    /// This returns [Self::default_parity] and sets
+    /// [TracingInspectorConfig::exclude_precompile_calls] if configured in the given
+    /// [FlatCallConfig]
     #[inline]
     pub fn from_flat_call_config(config: &FlatCallConfig) -> Self {
         Self::default_parity()

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -401,6 +401,7 @@ mod tests {
         assert!(!config.record_state_diff);
     }
 
+    #[test]
     fn test_flat_call_config() {
         let config = FlatCallConfig { include_precompiles: Some(true), ..Default::default() };
         let config = TracingInspectorConfig::from_flat_call_config(&config);

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -188,7 +188,7 @@ impl TracingInspectorConfig {
             .set_record_logs(config.with_log.unwrap_or_default())
     }
 
-    /// Returns a config for geth's [FlatCallTracer](alloy_rpc_types_trace::geth::FlatCallFrame).
+    /// Returns a config for geth's [FlatCallTracer](alloy_rpc_types_trace::geth::call::FlatCallFrame).
     ///
     /// This returns [Self::default_parity] and sets [TracingInspectorConfig::exclude_precompile_calls]
     /// if configured in the given [FlatCallConfig]

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::U256;
 use alloy_rpc_types_trace::{
-    geth::{CallConfig, GethDefaultTracingOptions, PreStateConfig},
+    geth::{CallConfig, FlatCallConfig, GethDefaultTracingOptions, PreStateConfig},
     parity::TraceType,
 };
 use revm::interpreter::OpCode;
@@ -186,6 +186,17 @@ impl TracingInspectorConfig {
         Self::none()
             // call tracer is similar parity tracer with optional support for logs
             .set_record_logs(config.with_log.unwrap_or_default())
+    }
+
+    /// Returns a config for geth's [FlatCallTracer](alloy_rpc_types_trace::geth::FlatCallFrame).
+    ///
+    /// This returns [Self::default_parity] and sets [TracingInspectorConfig::exclude_precompile_calls]
+    /// if configured in the given [FlatCallConfig]
+    #[inline]
+    pub fn from_flat_call_config(config: &FlatCallConfig) -> Self {
+        Self::default_parity()
+            // call tracer is similar parity tracer with optional support for logs
+            .set_exclude_precompile_calls(!config.include_precompiles.unwrap_or_default())
     }
 
     /// Returns a config for geth's [PrestateTracer](alloy_rpc_types_trace::geth::PreStateFrame).


### PR DESCRIPTION
For use and uniformity wrt https://github.com/paradigmxyz/reth/issues/10991

Simple tests included

I could do the PR without this but seems correct to maintain uniformity instead of modifying the `TracingInspector` in ad hoc ways