### PR TITLE
fix(js): the opposite checking logic

### DIFF
--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -265,7 +265,7 @@ impl MemoryRef {
                 move |_this, args, memory, ctx| {
                     let start = args.get_or_undefined(0).to_number(ctx)?;
                     let end = args.get_or_undefined(1).to_number(ctx)?;
-                    if end < start || start < 0. || (end as usize) < memory.len() {
+                    if end < start || start < 0. || (end as usize) > memory.len() {
                         return Err(JsError::from_native(JsNativeError::typ().with_message(
                             format!(
                                 "tracer accessed out of bound memory: offset {start}, end {end}"


### PR DESCRIPTION
Seems we're using the opposite judge logic to check the ending and memory length. found in https://github.com/paradigmxyz/revm-inspectors/actions/runs/11389609241/job/31689313431?pr=231