### PR TITLE
Fix grammatical errors in documentation

### DIFF
--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -38,7 +38,7 @@ impl ParityTraceBuilder {
         self.nodes.iter().map(|node| node.trace.caller).collect()
     }
 
-    /// Manually the gas used of the root trace.
+    /// Manually set the gas used of the root trace.
     ///
     /// The root trace's gasUsed should mirror the actual gas used by the transaction.
     ///

--- a/src/tracing/fourbyte.rs
+++ b/src/tracing/fourbyte.rs
@@ -1,6 +1,6 @@
 //! Fourbyte tracing inspector
 //!
-//! Solidity contract functions are addressed using the first four byte of the Keccak-256 hash of
+//! Solidity contract functions are addressed using the first four bytes of the Keccak-256 hash of
 //! their signature. Therefore when calling the function of a contract, the caller must send this
 //! function selector as well as the ABI-encoded arguments as call data.
 //!


### PR DESCRIPTION


- src/tracing/fourbyte.rs:
Old: "byte" -> New: "bytes"
Reason: Corrected to plural form since it refers to multiple (four) bytes

- src/tracing/builder/parity.rs:
Old: "Manually the gas used" -> New: "Manually set the gas used"
Reason: Added missing verb "set" for grammatical completeness

Documentation-only changes to improve clarity and correctness. No functional changes.