### PR TITLE
feat: add edge coverage tracking inspired by AFL/Lucid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 .vscode
 .idea
+.DS_Store

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -1,0 +1,107 @@
+use alloy_primitives::{Address, U256};
+use revm::{
+    interpreter::{opcode::OpCode, Interpreter},
+    Database, EvmContext, Inspector,
+};
+
+use std::hash::{Hash, Hasher};
+
+/// A hit count that never goes to zero e.g. the back edge of a loop that iterates 256 times will be
+/// one instead of zero.
+// see https://github.com/AFLplusplus/AFLplusplus/blob/5777ceaf23f48ae4ceae60e4f3a79263802633c6/instrumentation/afl-llvm-pass.so.cc#L810-L829
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NeverZeroHitCount(pub u8);
+
+impl std::ops::Add for NeverZeroHitCount {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        Self(self.0.checked_add(rhs.0).unwrap_or(1))
+    }
+}
+
+impl std::ops::AddAssign for NeverZeroHitCount {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+const MAX_EDGE_COUNT: usize = 65536;
+
+/// An Inspector that tracks edge coverage.
+#[derive(Clone, Debug, Default)]
+pub struct EdgeCovInspector {
+    /// Map of total gas used per opcode.
+    pub hitcount: Vec<NeverZeroHitCount>,
+}
+
+impl EdgeCovInspector {
+    /// Create a new EdgeCovInspector.
+    pub fn new() -> Self {
+        Self { hitcount: vec![NeverZeroHitCount(0); MAX_EDGE_COUNT] }
+    }
+
+    /// Reset the hitcount to zero.
+    pub fn reset(&mut self) {
+        self.hitcount.fill(NeverZeroHitCount(0));
+    }
+}
+
+fn edge_hash(address: Address, pc: usize, jump_dest: U256) -> u32 {
+    // TODO faster hash https://h0mbre.github.io/Lucid_Snapshots_Coverage/
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    address.hash(&mut hasher);
+    pc.hash(&mut hasher);
+    jump_dest.hash(&mut hasher);
+    (hasher.finish() as usize % MAX_EDGE_COUNT) as u32
+}
+
+impl<DB> Inspector<DB> for EdgeCovInspector
+where
+    DB: Database,
+{
+    fn step(&mut self, interp: &mut Interpreter, _context: &mut EvmContext<DB>) {
+        let address = interp.contract.target_address; // TODO track context for delegatecall?
+        let current_pc = interp.program_counter();
+        let opcode_value = interp.current_opcode();
+        if let Some(op) = OpCode::new(opcode_value) {
+            match op {
+                OpCode::JUMP => {
+                    // unconditional jump
+                    if let Ok(jump_dest) = interp.stack().peek(0) {
+                        let edge_id = edge_hash(address, current_pc, jump_dest);
+                        self.hitcount[edge_id as usize] += NeverZeroHitCount(1);
+                    }
+                }
+                OpCode::JUMPI => {
+                    if let Ok(stack_value) = interp.stack().peek(0) {
+                        let jump_dest = if stack_value == U256::from(1) {
+                            // branch taken
+                            interp.stack().peek(1).unwrap()
+                        } else {
+                            // fall through
+                            U256::from(current_pc + 1)
+                        };
+                        let edge_id = edge_hash(address, current_pc, jump_dest);
+                        self.hitcount[edge_id as usize] += NeverZeroHitCount(1);
+                    }
+                }
+                _ => {
+                    // no-op
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nonzero_hitcount() {
+        let mut hitcount = NeverZeroHitCount(255);
+        hitcount += NeverZeroHitCount(1);
+        assert_eq!(hitcount.0, 1);
+    }
+}

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -38,7 +38,7 @@ impl EdgeCovInspector {
         self.hitcount.as_slice()
     }
 
-    /// Consume the inspector and take ownership of the hitcount..
+    /// Consume the inspector and take ownership of the hitcount.
     pub fn take_hitcount(&mut self) -> Vec<u8> {
         std::mem::take(&mut self.hitcount)
     }

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -46,7 +46,7 @@ impl EdgeCovInspector {
         jump_dest.hash(&mut hasher);
         // The hash is used to index into the hitcount array, so it must be modulo the maximum edge
         // count.
-        let edge_id = (hasher.finish() as usize % MAX_EDGE_COUNT) as u32 as usize;
+        let edge_id = (hasher.finish() % MAX_EDGE_COUNT as u64) as usize;
         self.hitcount[edge_id] = self.hitcount[edge_id].checked_add(1).unwrap_or(1);
     }
 }

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -1,9 +1,6 @@
 use alloc::{vec, vec::Vec};
 use alloy_primitives::{map::DefaultHashBuilder, Address, U256};
-use core::{
-    hash::{BuildHasher, Hash, Hasher},
-    mem,
-};
+use core::hash::{BuildHasher, Hash, Hasher};
 use revm::{
     interpreter::{
         opcode::{self},
@@ -43,8 +40,8 @@ impl EdgeCovInspector {
     }
 
     /// Consume the inspector and take ownership of the hitcount.
-    pub fn take_hitcount(&mut self) -> Vec<u8> {
-        mem::take(&mut self.hitcount)
+    pub fn into_hitcount(self) -> Vec<u8> {
+        self.hitcount
     }
 
     /// Mark the edge, H(address, pc, jump_dest), as hit.

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -33,9 +33,14 @@ impl EdgeCovInspector {
         self.hitcount.fill(0);
     }
 
-    /// Get the hitcount as a byte vector.
+    /// Get an immutable reference to the hitcount.
     pub fn get_hitcount(&self) -> &[u8] {
         self.hitcount.as_slice()
+    }
+
+    /// Consume the inspector and take ownership of the hitcount..
+    pub fn take_hitcount(&mut self) -> Vec<u8> {
+        std::mem::take(&mut self.hitcount)
     }
 
     /// Mark the edge, H(address, pc, jump_dest), as hit.

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -1,5 +1,9 @@
+use alloc::{vec, vec::Vec};
 use alloy_primitives::{map::DefaultHashBuilder, Address, U256};
-use core::hash::{BuildHasher, Hash, Hasher};
+use core::{
+    hash::{BuildHasher, Hash, Hasher},
+    mem,
+};
 use revm::{
     interpreter::{
         opcode::{self},
@@ -40,7 +44,7 @@ impl EdgeCovInspector {
 
     /// Consume the inspector and take ownership of the hitcount.
     pub fn take_hitcount(&mut self) -> Vec<u8> {
-        std::mem::take(&mut self.hitcount)
+        mem::take(&mut self.hitcount)
     }
 
     /// Mark the edge, H(address, pc, jump_dest), as hit.

--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -10,7 +10,7 @@ use revm::{
 const MAX_EDGE_COUNT: usize = 65536;
 
 /// An `Inspector` that tracks [edge coverage](https://clang.llvm.org/docs/SanitizerCoverage.html#edge-coverage).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct EdgeCovInspector {
     /// Map of hitcounts that can be diffed against to determine if new coverage was reached.
     hitcount: Vec<NeverZeroHitCount>,
@@ -30,6 +30,12 @@ impl EdgeCovInspector {
     /// Get the hitcount as a byte vector.
     pub fn get_hitcount(&self) -> Vec<u8> {
         self.hitcount.iter().map(|x| x.0).collect()
+    }
+}
+
+impl Default for EdgeCovInspector {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,4 +30,7 @@ pub mod tracing;
 /// An inspector for recording internal transfers.
 pub mod transfer;
 
+/// An inspector for tracking edge coverage.
+pub mod edge_cov;
+
 pub use colorchoice::ColorChoice;

--- a/tests/it/edge_cov.rs
+++ b/tests/it/edge_cov.rs
@@ -82,8 +82,6 @@ fn test_edge_coverage() {
     assert!(res.result.is_success());
 
     let counts = insp.get_hitcount();
-    // The `break` statement prevents the post-increment of the loop counter, so we expect 1 less
-    // edge to be hit.
     assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 11);
     assert_eq!(counts.iter().filter(|&x| *x == 1).count(), 11);
 
@@ -101,10 +99,10 @@ fn test_edge_coverage() {
     let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
     assert!(res.result.is_success());
 
-    // There should be 12 non-zero counts and that two edges have been hit 255 times.
-    let mut counts = insp.get_hitcount();
+    // There should be 13 non-zero counts and two edges that have been hit 255 times.
+    let mut counts = insp.get_hitcount().to_owned();
     counts.sort();
     assert_eq!(counts[counts.len() - 1], 255);
     assert_eq!(counts[counts.len() - 2], 255);
-    assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 12);
+    assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 13);
 }

--- a/tests/it/edge_cov.rs
+++ b/tests/it/edge_cov.rs
@@ -100,7 +100,7 @@ fn test_edge_coverage() {
     assert!(res.result.is_success());
 
     // There should be 13 non-zero counts and two edges that have been hit 255 times.
-    let mut counts = insp.take_hitcount();
+    let mut counts = insp.into_hitcount();
     counts.sort();
     assert_eq!(counts[counts.len() - 1], 255);
     assert_eq!(counts[counts.len() - 2], 255);

--- a/tests/it/edge_cov.rs
+++ b/tests/it/edge_cov.rs
@@ -81,7 +81,7 @@ fn test_edge_coverage() {
     let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
     assert!(res.result.is_success());
 
-    let mut counts: Vec<u8> = insp.hitcount.iter().map(|x| x.0).collect();
+    let counts = insp.get_hitcount();
     // The `break` statement prevents the post-increment of the loop counter, so we expect 1 less
     // edge to be hit.
     assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 11);
@@ -102,7 +102,7 @@ fn test_edge_coverage() {
     assert!(res.result.is_success());
 
     // There should be 12 non-zero counts and that two edges have been hit 255 times.
-    counts = insp.hitcount.iter().map(|x| x.0).collect();
+    let mut counts = insp.get_hitcount();
     counts.sort();
     assert_eq!(counts[counts.len() - 1], 255);
     assert_eq!(counts[counts.len() - 2], 255);

--- a/tests/it/edge_cov.rs
+++ b/tests/it/edge_cov.rs
@@ -100,7 +100,7 @@ fn test_edge_coverage() {
     assert!(res.result.is_success());
 
     // There should be 13 non-zero counts and two edges that have been hit 255 times.
-    let mut counts = insp.get_hitcount().to_owned();
+    let mut counts = insp.take_hitcount();
     counts.sort();
     assert_eq!(counts[counts.len() - 1], 255);
     assert_eq!(counts[counts.len() - 2], 255);

--- a/tests/it/edge_cov.rs
+++ b/tests/it/edge_cov.rs
@@ -1,0 +1,110 @@
+//! Edge coverage tests
+
+use alloy_primitives::{hex, Address, U256};
+use revm::{
+    db::{CacheDB, EmptyDB},
+    primitives::{
+        BlockEnv, CfgEnv, CfgEnvWithHandlerCfg, EnvWithHandlerCfg, ExecutionResult, HandlerCfg,
+        Output, SpecId, TransactTo, TxEnv,
+    },
+    DatabaseCommit,
+};
+
+use crate::utils::inspect;
+use revm_inspectors::{
+    edge_cov::EdgeCovInspector,
+    tracing::{TracingInspector, TracingInspectorConfig},
+};
+
+#[test]
+fn test_edge_coverage() {
+    /*
+    contract X {
+        function Y(bool yes) external {
+            for (uint256 i = 0; i < 255; i++) {
+                if (yes) {
+                    break;
+                }
+            }
+        }
+    }
+    */
+
+    let code = hex!("6080604052348015600f57600080fd5b5060b580601d6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c8063f42e8cdd14602d575b600080fd5b603c60383660046058565b603e565b005b60005b60ff811015605457816054576001016041565b5050565b600060208284031215606957600080fd5b81358015158114607857600080fd5b939250505056fea2646970667358221220a206d90c473b6930258d5789495c41b79941b5334c47a76b6e618d3571716d5164736f6c634300081c0033");
+    let deployer = Address::ZERO;
+
+    let mut db = CacheDB::new(EmptyDB::default());
+
+    let cfg = CfgEnvWithHandlerCfg::new(CfgEnv::default(), HandlerCfg::new(SpecId::LONDON));
+
+    let env = EnvWithHandlerCfg::new_with_cfg_env(
+        cfg.clone(),
+        BlockEnv::default(),
+        TxEnv {
+            caller: deployer,
+            gas_limit: 1000000,
+            transact_to: TransactTo::Create,
+            data: code.into(),
+            ..Default::default()
+        },
+    );
+
+    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
+
+    // Create contract
+    let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
+    let addr = match res.result {
+        ExecutionResult::Success { output, .. } => match output {
+            Output::Create(_, addr) => addr.unwrap(),
+            _ => panic!("Create failed"),
+        },
+        _ => panic!("Execution failed"),
+    };
+    db.commit(res.state);
+
+    let acc = db.load_account(deployer).unwrap();
+    acc.info.balance = U256::from(u64::MAX);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 100000000,
+        transact_to: TransactTo::Call(addr),
+        // 'cast cd "Y(bool)" true'
+        data: hex!("f42e8cdd0000000000000000000000000000000000000000000000000000000000000001")
+            .into(),
+        ..Default::default()
+    };
+
+    let mut insp = EdgeCovInspector::new();
+
+    let env = EnvWithHandlerCfg::new_with_cfg_env(cfg.clone(), BlockEnv::default(), tx_env.clone());
+    let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
+    assert!(res.result.is_success());
+
+    let mut counts: Vec<u8> = insp.hitcount.iter().map(|x| x.0).collect();
+    // The `break` statement prevents the post-increment of the loop counter, so we expect 1 less
+    // edge to be hit.
+    assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 11);
+    assert_eq!(counts.iter().filter(|&x| *x == 1).count(), 11);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 100000000,
+        transact_to: TransactTo::Call(addr),
+        // 'cast cd "Y(bool)" false'
+        data: hex!("f42e8cdd0000000000000000000000000000000000000000000000000000000000000000")
+            .into(),
+        ..Default::default()
+    };
+    let env = EnvWithHandlerCfg::new_with_cfg_env(cfg.clone(), BlockEnv::default(), tx_env.clone());
+    insp.reset();
+    let (res, _) = inspect(&mut db, env, &mut insp).unwrap();
+    assert!(res.result.is_success());
+
+    // There should be 12 non-zero counts and that two edges have been hit 255 times.
+    counts = insp.hitcount.iter().map(|x| x.0).collect();
+    counts.sort();
+    assert_eq!(counts[counts.len() - 1], 255);
+    assert_eq!(counts[counts.len() - 2], 255);
+    assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 12);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -3,6 +3,8 @@
 pub mod utils;
 
 #[cfg(feature = "std")]
+mod edge_cov;
+#[cfg(feature = "std")]
 mod geth;
 #[cfg(feature = "js-tracer")]
 mod geth_js;


### PR DESCRIPTION
For use in Foundry coverage guided fuzzing. I think the other functionality such as [comparing two edge maps](https://github.com/h0mbre/Lucid/blob/3026e7323c52b30b3cf12563954ac1eaa9c6981e/src/coverage.rs#L72) can be added later or in Foundry directly 