### PR TITLE
feat: simplify AccessListInspector API

### DIFF
--- a/src/access_list.rs
+++ b/src/access_list.rs
@@ -1,3 +1,4 @@
+use alloc::collections::BTreeSet;
 use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, TxKind, B256,
@@ -7,7 +8,6 @@ use revm::{
     interpreter::{opcode, Interpreter},
     Database, EvmContext, Inspector,
 };
-use std::collections::BTreeSet;
 
 /// An [Inspector] that collects touched accounts and storage slots.
 ///


### PR DESCRIPTION
Right now caller is required to provide `AccessListInspector` with the list of precompiles which is unnecessary and requires caller to peek into EVM internals. Besides making API more complex this also results in reth not excluding p256 OP precompile when preparing access list https://github.com/paradigmxyz/reth/blob/890507a98adef94b3970312ef796eb40f87206df/crates/rpc/rpc-eth-api/src/helpers/call.rs#L430-L431

This PR changes `AccessListInspector` to obtain `from`, `to` and `precompiles` from the top-level frame and not requiring caller to provide anything