### PR TITLE
chore: Fix incorrect function check in mod.rs

### DIFF
--- a/src/tracing/js/mod.rs
+++ b/src/tracing/js/mod.rs
@@ -355,7 +355,7 @@ impl JsInspector {
     /// Returns true if there's an exit function and the active call is not the root call.
     #[inline]
     fn can_call_exit(&mut self) -> bool {
-        self.enter_fn.is_some() && !self.is_root_call_active()
+        self.exit_fn.is_some() && !self.is_root_call_active()
     }
 
     /// Pushes a new call to the stack


### PR DESCRIPTION
`self.enter_fn.is_some()` is used in the `can_call_exit` method to check for the presence of an entry function (`enter_fn`). This is incorrect, as the method should be checking for the exit function (`exit_fn`).
I've fixed this by updating the check to `self.exit_fn.is_some()`. This aligns with the method's intended behavior.
