### PR TITLE
Grammar and Clarity Improvements in Code Comments

### DIFF
--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -19,9 +19,9 @@ use thiserror::Error;
 /// Mux tracing inspector that runs and collects results of multiple inspectors at once.
 #[derive(Clone, Debug)]
 pub struct MuxInspector {
-    /// A instance of FourByteInspector that can be reused
+    /// An instance of FourByteInspector that can be reused
     four_byte: Option<FourByteInspector>,
-    /// A instance of TracingInspector that can be reused
+    /// An instance of TracingInspector that can be reused
     tracing: Option<TracingInspector>,
     /// Configurations for different Geth trace types
     configs: Vec<(GethDebugBuiltInTracerType, TraceConfig)>,

--- a/src/tracing/utils.rs
+++ b/src/tracing/utils.rs
@@ -52,7 +52,7 @@ pub(crate) fn load_account_code<DB: DatabaseRef>(
     })
 }
 
-/// Returns a non empty revert reason if the output is a revert/error.
+/// Returns a non-empty revert reason if the output is a revert/error.
 #[inline]
 pub(crate) fn maybe_revert_reason(output: &[u8]) -> Option<String> {
     let reason = match GenericRevertReason::decode(output)? {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -190,7 +190,7 @@ pub struct TransferOperation {
 /// The kind of transfer operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransferKind {
-    /// A non zero value transfer CALL
+    /// A non-zero value transfer CALL
     Call,
     /// A CREATE operation
     Create,


### PR DESCRIPTION


### 1. File: `src/tracing/mux.rs`
- **Old:** `/// A instance of FourByteInspector that can be reused`
- **New:** `/// An instance of FourByteInspector that can be reused`
- **Reason:** Corrected the grammatical error by changing "A" to "An" to ensure proper article usage before a vowel sound.

### 2. File: `src/tracing/utils.rs`
- **Old:** `/// Returns a non empty revert reason if the output is a revert/error.`
- **New:** `/// Returns a non-empty revert reason if the output is a revert/error.`
- **Reason:** Added a hyphen to "non-empty" to correctly form the compound adjective, improving clarity and grammatical accuracy.

### 3. File: `src/transfer.rs`
- **Old:** `/// A non zero value transfer CALL`
- **New:** `/// A non-zero value transfer CALL`
- **Reason:** Added a hyphen to "non-zero" to correctly form the compound adjective, enhancing clarity and grammatical correctness.

## Summary
These changes improve the grammatical accuracy and clarity of the comments in the code, ensuring that the documentation is professional and easy to understand. Proper use of articles and hyphenation in compound adjectives is essential for maintaining high-quality code documentation.