### PR TITLE
Update utils.rs

### DIFF
--- a/src/tracing/utils.rs
+++ b/src/tracing/utils.rs
@@ -1,4 +1,4 @@
-//! Util functions for revm related ops
+//! Utility functions for revm related ops
 use alloc::{
     string::{String, ToString},
     vec::Vec,


### PR DESCRIPTION

Old: //! Util functions for revm related ops

New: //! Utility functions for revm related ops

Reason: The word "Util" was replaced with "Utility" to improve readability and maintain consistency with standard English usage. This makes the comment more professional and easier to understand.