### PR TITLE
fix: reversed JUMPI args

### DIFF
--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -77,10 +77,10 @@ impl<CTX> Inspector<CTX> for EdgeCovInspector {
                 }
             }
             opcode::JUMPI => {
-                if let Ok(stack_value) = interp.stack.peek(0) {
+                if let Ok(stack_value) = interp.stack.peek(1) {
                     let jump_dest = if !stack_value.is_zero() {
                         // branch taken
-                        interp.stack.peek(1)
+                        interp.stack.peek(0)
                     } else {
                         // fall through
                         Ok(U256::from(current_pc + 1))


### PR DESCRIPTION
closes https://github.com/paradigmxyz/revm-inspectors/issues/271

h/t @MiloTruck