### PR TITLE
fix: populate selfdestructs in localized parity

### DIFF
--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -427,10 +427,10 @@ where
             // find the next selfdestruct to yield
             if let Some((next_trace, _)) = self.iter.peek() {
                 // find the most recently recorded selfdestruct that has a lower address
-                if let Some(pos) =
-                    self.next_selfdestructs.iter().rev().position(|selfdestruct| {
-                        selfdestruct.trace_address < next_trace.trace_address
-                    })
+                if let Some(pos) = self
+                    .next_selfdestructs
+                    .iter()
+                    .rposition(|selfdestruct| selfdestruct.trace_address < next_trace.trace_address)
                 {
                     return Some(self.next_selfdestructs.remove(pos));
                 }

--- a/tests/it/parity.rs
+++ b/tests/it/parity.rs
@@ -245,7 +245,7 @@ fn test_parity_call_selfdestruct() {
     );
 }
 
-// Minimal example of <https://github.com/paradigmxyz/reth/issues/15150, <0x0b0c51740c9fa9f6b9120410ccaac2eb51b81200a64b6fe0b886c762eb03f48b>
+// Minimal example of <https://github.com/paradigmxyz/reth/issues/15150>, 0x0b0c51740c9fa9f6b9120410ccaac2eb51b81200a64b6fe0b886c762eb03f48b
 #[test]
 fn test_parity_call_selfdestruct_create() {
     let caller = address!("0x61984a7191314323c2A748538717934e44Fc3FF6");


### PR DESCRIPTION
closes https://github.com/paradigmxyz/reth/issues/15150

the bug here was that we didn't record all selfdestructs and replaced previous ones (higher address) if there was another selfdestruct.

this fixes this by recording selfdestructs in a stack