### PR TITLE
Disable Revm default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,11 @@ clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth
-alloy-rpc-types-eth = "0.13"
-alloy-rpc-types-trace = "0.13"
-alloy-sol-types = "0.8"
-alloy-primitives = { version = "0.8", features = ["map"] }
-revm = "21.0.0"
+alloy-rpc-types-eth = { version = "0.13", default-features = false }
+alloy-rpc-types-trace = { version = "0.13", default-features = false }
+alloy-sol-types = { version = "0.8", default-features = false }
+alloy-primitives = { version = "0.8", default-features = false, features = ["map"] }
+revm = { version = "21.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
`revm-inspector` imports `revm` with the default features enabled. This causes an issue where it's not possible to disable Revm's default features when this crate is imported. This PR resolves the problem by explicitly disabling those features, as they are not required by `revm-inspector`.