### PR TITLE
chore(access-list): Add function to access touched slots

### DIFF
--- a/src/access_list.rs
+++ b/src/access_list.rs
@@ -60,6 +60,12 @@ impl AccessListInspector {
         &self.access_list
     }
 
+    /// Consumes the inspector and returns the map of addresses and their corresponding touched
+    /// storage slots.
+    pub fn into_touched_slots(self) -> HashMap<Address, BTreeSet<B256>> {
+        self.access_list
+    }
+
     /// Returns list of addresses and storage keys used by the transaction. It gives you the list of
     /// addresses and storage keys that were touched during execution.
     pub fn into_access_list(self) -> AccessList {

--- a/src/access_list.rs
+++ b/src/access_list.rs
@@ -55,6 +55,11 @@ impl AccessListInspector {
         &self.excluded
     }
 
+    /// Returns a reference to the map of addresses and their corresponding touched storage slots.
+    pub fn touched_slots(&self) -> &HashMap<Address, BTreeSet<B256>> {
+        &self.access_list
+    }
+
     /// Returns list of addresses and storage keys used by the transaction. It gives you the list of
     /// addresses and storage keys that were touched during execution.
     pub fn into_access_list(self) -> AccessList {


### PR DESCRIPTION
Since there is no way to access the internal map, this PR introduces a `fn touched_slots`. To avoid conflicting with the semantics of `fn access_list`, I named it `touched_slots`. The reason for this is that using the map speeds up the process of checking whether certain slots have been touched.