### PR TITLE
fix: correct Ref<[u8]> to &[u8] conversion in FourByteInspector

### DIFF
--- a/src/tracing/fourbyte.rs
+++ b/src/tracing/fourbyte.rs
@@ -52,7 +52,7 @@ impl<CTX: ContextTr> Inspector<CTX> for FourByteInspector {
                     match context.local().shared_memory_buffer_slice(range.clone()) {
                         Some(slice) => {
                             r = slice;
-                            r.as_ref()
+                            &*r
                         }
                         None => &[],
                     }


### PR DESCRIPTION
When using revm-inspectors as a dependency in my project, I encountered the following compilation error:
```
error[E0277]: the trait bound `[u8]: AsRef<[_; 0]>` is not satisfied
  --> /home/cheddie/.cargo/git/checkouts/revm-inspectors-c863f094e4c77dd4/9fe2ce1/src/tracing/fourbyte.rs:55:31
   |
55 | ...                   r.as_ref()
   |                         ^^^^^^ the trait `AsRef<[_; 0]>` is not implemented for `[u8]`
   |
   = help: the following other types implement trait `AsRef<T>`:
             `[u8]` implements `AsRef<winnow::stream::bstr::BStr>`
             `[u8]` implements `AsRef<winnow::stream::bytes::Bytes>`
```
After this fix, the crate compiles successfully when used as a dependency.

I'm happy to make any adjustments if there's a more idiomatic way to handle this conversion.