### PR TITLE
feat(mux-tracer): Support JS tracer in MUX tracer.

### DIFF
--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -250,7 +250,7 @@ impl DebugInspector {
             Self::Js(inspector, _, _) => {
                 inspector.set_transaction_context(tx_context.unwrap_or_default());
                 let res = inspector
-                    .json_result(res.clone(), tx_env, block_env, db)
+                    .json_result(&res, tx_env, block_env, db)
                     .map_err(DebugInspectorError::JsInspector)?;
 
                 GethTrace::JS(res)

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -57,6 +57,8 @@ pub use writer::{TraceWriter, TraceWriterConfig};
 pub mod js;
 
 mod mux;
+#[cfg(feature = "js-tracer")]
+pub use mux::MuxConfigExt;
 pub use mux::{Error as MuxError, MuxInspector};
 
 mod debug;

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -7,6 +7,10 @@ use alloy_rpc_types_trace::geth::{
     CallConfig, FlatCallConfig, FourByteFrame, GethDebugBuiltInTracerType, NoopFrame,
     PreStateConfig,
 };
+#[cfg(feature = "js-tracer")]
+use alloy_rpc_types_trace::geth::{GethDebugTracerConfig, GethDebugTracerType, GethTrace};
+#[cfg(feature = "js-tracer")]
+use revm::context::{Block, Transaction};
 use revm::{
     context_interface::{
         result::{HaltReasonTr, ResultAndState},
@@ -18,11 +22,17 @@ use revm::{
 };
 use thiserror::Error;
 
+#[cfg(feature = "js-tracer")]
+use crate::tracing::js::{JsInspector, JsInspectorError};
+
 /// Mux tracing inspector that runs and collects results of multiple inspectors at once.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MuxInspector {
     /// An instance of FourByteInspector that can be reused
     four_byte: Option<FourByteInspector>,
+    /// An instance of JsInspector that can be reused
+    #[cfg(feature = "js-tracer")]
+    js_tracer: Option<JsInspector>,
     /// An instance of TracingInspector that can be reused
     tracing: Option<TracingInspector>,
     /// Configurations for different Geth trace types
@@ -38,8 +48,19 @@ enum TraceConfig {
     Noop,
 }
 
+/// Extended mux configuration that supports JS tracers.
+///
+/// This wraps a HashMap of `GethDebugTracerType` to optional configs,
+/// allowing both built-in tracers and JS tracers to be configured.
+#[cfg(feature = "js-tracer")]
+#[derive(Clone, Debug, Default)]
+pub struct MuxConfigExt(pub HashMap<GethDebugTracerType, Option<GethDebugTracerConfig>>);
+
 impl MuxInspector {
     /// Try creating a new instance of [MuxInspector] from the given [MuxConfig].
+    ///
+    /// Note: This only supports built-in tracers. For JS tracer support, use
+    /// [`try_from_config_ext`](Self::try_from_config_ext).
     pub fn try_from_config(config: MuxConfig) -> Result<MuxInspector, Error> {
         let mut four_byte = None;
         let mut inspector_config = TracingInspectorConfig::none();
@@ -51,7 +72,7 @@ impl MuxInspector {
             match tracer_type {
                 GethDebugBuiltInTracerType::FourByteTracer => {
                     if tracer_config.is_some() {
-                        return Err(Error::UnexpectedConfig(tracer_type));
+                        return Err(Error::UnexpectedBuiltInConfig(tracer_type));
                     }
                     four_byte = Some(FourByteInspector::default());
                 }
@@ -75,7 +96,7 @@ impl MuxInspector {
                 }
                 GethDebugBuiltInTracerType::NoopTracer => {
                     if tracer_config.is_some() {
-                        return Err(Error::UnexpectedConfig(tracer_type));
+                        return Err(Error::UnexpectedBuiltInConfig(tracer_type));
                     }
                     configs.push((tracer_type, TraceConfig::Noop));
                 }
@@ -89,21 +110,116 @@ impl MuxInspector {
                     configs.push((tracer_type, TraceConfig::FlatCall(flatcall_config)));
                 }
                 GethDebugBuiltInTracerType::MuxTracer => {
-                    return Err(Error::UnexpectedConfig(tracer_type));
+                    return Err(Error::UnexpectedBuiltInConfig(tracer_type));
                 }
                 _ => {
                     // keep this so that new variants can be supported
-                    return Err(Error::UnexpectedConfig(tracer_type));
+                    return Err(Error::UnexpectedBuiltInConfig(tracer_type));
                 }
             }
         }
 
         let tracing = (!configs.is_empty()).then(|| TracingInspector::new(inspector_config));
 
-        Ok(MuxInspector { four_byte, tracing, configs })
+        Ok(MuxInspector {
+            four_byte,
+            #[cfg(feature = "js-tracer")]
+            js_tracer: None,
+            tracing,
+            configs,
+        })
+    }
+
+    /// Try creating a new instance of [MuxInspector] from the given extended [MuxConfigExt].
+    ///
+    /// This supports both built-in tracers and JS tracers.
+    #[cfg(feature = "js-tracer")]
+    pub fn try_from_config_ext(config: MuxConfigExt) -> Result<MuxInspector, Error> {
+        let mut four_byte = None;
+        let mut js_tracer: Option<JsInspector> = None;
+        let mut inspector_config = TracingInspectorConfig::none();
+        let mut configs = Vec::new();
+
+        // Process each tracer configuration
+        for (tracer_type, tracer_config) in config.0 {
+            match tracer_type {
+                GethDebugTracerType::BuiltInTracer(built_in_tracer_type) => {
+                    match built_in_tracer_type {
+                        GethDebugBuiltInTracerType::FourByteTracer => {
+                            if tracer_config.is_some() {
+                                return Err(Error::UnexpectedConfig(tracer_type));
+                            }
+                            four_byte = Some(FourByteInspector::default());
+                        }
+                        GethDebugBuiltInTracerType::CallTracer => {
+                            let call_config = tracer_config
+                                .ok_or(Error::MissingBuiltInConfig(built_in_tracer_type))?
+                                .into_call_config()?;
+
+                            inspector_config
+                                .merge(TracingInspectorConfig::from_geth_call_config(&call_config));
+                            configs.push((built_in_tracer_type, TraceConfig::Call(call_config)));
+                        }
+                        GethDebugBuiltInTracerType::PreStateTracer => {
+                            let prestate_config = tracer_config
+                                .ok_or(Error::MissingBuiltInConfig(built_in_tracer_type))?
+                                .into_pre_state_config()?;
+
+                            inspector_config.merge(
+                                TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
+                            );
+                            configs.push((
+                                built_in_tracer_type,
+                                TraceConfig::PreState(prestate_config),
+                            ));
+                        }
+                        GethDebugBuiltInTracerType::NoopTracer => {
+                            if tracer_config.is_some() {
+                                return Err(Error::UnexpectedConfig(tracer_type));
+                            }
+                            configs.push((built_in_tracer_type, TraceConfig::Noop));
+                        }
+                        GethDebugBuiltInTracerType::FlatCallTracer => {
+                            let flatcall_config = tracer_config
+                                .ok_or(Error::MissingBuiltInConfig(built_in_tracer_type))?
+                                .into_flat_call_config()?;
+
+                            inspector_config.merge(TracingInspectorConfig::from_flat_call_config(
+                                &flatcall_config,
+                            ));
+                            configs.push((
+                                built_in_tracer_type,
+                                TraceConfig::FlatCall(flatcall_config),
+                            ));
+                        }
+                        GethDebugBuiltInTracerType::MuxTracer => {
+                            return Err(Error::UnexpectedConfig(tracer_type));
+                        }
+                        _ => {
+                            return Err(Error::UnexpectedConfig(tracer_type));
+                        }
+                    }
+                }
+                GethDebugTracerType::JsTracer(ref code) => {
+                    let config = match tracer_config {
+                        Some(config) => config.into_json(),
+                        None => serde_json::Value::Null,
+                    };
+
+                    js_tracer = Some(JsInspector::new(code.clone(), config)?);
+                }
+            }
+        }
+
+        let tracing = (!configs.is_empty()).then(|| TracingInspector::new(inspector_config));
+
+        Ok(MuxInspector { four_byte, js_tracer, tracing, configs })
     }
 
     /// Try converting this [MuxInspector] into a [MuxFrame].
+    ///
+    /// Note: This only returns built-in tracer results. For JS tracer support, use
+    /// [`try_into_mux_frame_ext`](Self::try_into_mux_frame_ext).
     pub fn try_into_mux_frame<DB: DatabaseRef>(
         &self,
         result: &ResultAndState<impl HaltReasonTr>,
@@ -161,11 +277,41 @@ impl MuxInspector {
 
         Ok(MuxFrame(frame))
     }
+
+    /// Try converting this [MuxInspector] into an extended mux frame.
+    ///
+    /// Returns a tuple of `(MuxFrame, Option<GethTrace>)` where:
+    /// - `MuxFrame` contains all built-in tracer results
+    /// - `Option<GethTrace>` contains the JS tracer result if configured
+    #[cfg(feature = "js-tracer")]
+    pub fn try_into_mux_frame_ext<DB: DatabaseRef>(
+        &mut self,
+        result: &ResultAndState<impl HaltReasonTr>,
+        tx: &impl Transaction,
+        block: &impl Block,
+        db: &DB,
+        tx_info: TransactionInfo,
+    ) -> Result<(MuxFrame, Option<GethTrace>), DB::Error> {
+        let mux_frame = self.try_into_mux_frame(result, db, tx_info)?;
+
+        // Get js tracer result if inspector exists
+        let js_result = if let Some(ref mut js_inspector) = self.js_tracer {
+            Some(GethTrace::JS(
+                js_inspector
+                    .json_result(result, tx, block, db)
+                    .unwrap_or_else(|err| serde_json::json!({ "error": err.to_string() })),
+            ))
+        } else {
+            None
+        };
+
+        Ok((mux_frame, js_result))
+    }
 }
 
 impl<CTX> Inspector<CTX> for MuxInspector
 where
-    CTX: ContextTr<Journal: JournalExt>,
+    CTX: ContextTr<Journal: JournalExt, Db: DatabaseRef>,
 {
     #[inline]
     fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut CTX) {
@@ -173,6 +319,10 @@ where
             inspector.initialize_interp(interp, context);
         }
         if let Some(ref mut inspector) = self.tracing {
+            inspector.initialize_interp(interp, context);
+        }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
             inspector.initialize_interp(interp, context);
         }
     }
@@ -185,6 +335,10 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.step(interp, context);
         }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
+            inspector.step(interp, context);
+        }
     }
 
     #[inline]
@@ -195,11 +349,19 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.step_end(interp, context);
         }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
+            inspector.step_end(interp, context);
+        }
     }
 
     #[inline]
     fn log(&mut self, context: &mut CTX, log: Log) {
         if let Some(ref mut inspector) = self.four_byte {
+            inspector.log(context, log.clone());
+        }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
             inspector.log(context, log.clone());
         }
         if let Some(ref mut inspector) = self.tracing {
@@ -210,6 +372,10 @@ where
     #[inline]
     fn log_full(&mut self, interp: &mut Interpreter, context: &mut CTX, log: Log) {
         if let Some(ref mut inspector) = self.four_byte {
+            inspector.log_full(interp, context, log.clone());
+        }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
             inspector.log_full(interp, context, log.clone());
         }
         if let Some(ref mut inspector) = self.tracing {
@@ -223,6 +389,10 @@ where
             let _ = inspector.call(context, inputs);
         }
         if let Some(ref mut inspector) = self.tracing {
+            let _ = inspector.call(context, inputs);
+        }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
             return inspector.call(context, inputs);
         }
         None
@@ -236,6 +406,10 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.call_end(context, inputs, outcome);
         }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
+            inspector.call_end(context, inputs, outcome);
+        }
     }
 
     #[inline]
@@ -244,6 +418,10 @@ where
             let _ = inspector.create(context, inputs);
         }
         if let Some(ref mut inspector) = self.tracing {
+            let _ = inspector.create(context, inputs);
+        }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
             return inspector.create(context, inputs);
         }
         None
@@ -262,6 +440,10 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.create_end(context, inputs, outcome);
         }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
+            inspector.create_end(context, inputs, outcome);
+        }
     }
 
     #[inline]
@@ -272,6 +454,10 @@ where
         if let Some(ref mut inspector) = self.tracing {
             <TracingInspector as Inspector<CTX>>::selfdestruct(inspector, contract, target, value);
         }
+        #[cfg(feature = "js-tracer")]
+        if let Some(ref mut inspector) = self.js_tracer {
+            <JsInspector as Inspector<CTX>>::selfdestruct(inspector, contract, target, value);
+        }
     }
 }
 
@@ -279,12 +465,24 @@ where
 #[derive(Debug, Error)]
 pub enum Error {
     /// Config was provided for a tracer that does not expect it
+    #[cfg(feature = "js-tracer")]
     #[error("unexpected config for tracer '{0:?}'")]
-    UnexpectedConfig(GethDebugBuiltInTracerType),
+    UnexpectedConfig(GethDebugTracerType),
+    /// Config was provided for a built-in tracer that does not expect it
+    #[error("unexpected config for tracer '{0:?}'")]
+    UnexpectedBuiltInConfig(GethDebugBuiltInTracerType),
     /// Expected config is missing
     #[error("expected config is missing for tracer '{0:?}'")]
     MissingConfig(GethDebugBuiltInTracerType),
+    /// Expected config is missing for built-in tracer
+    #[cfg(feature = "js-tracer")]
+    #[error("expected config is missing for tracer '{0:?}'")]
+    MissingBuiltInConfig(GethDebugBuiltInTracerType),
     /// Error when deserializing the config
     #[error("error deserializing config: {0}")]
     InvalidConfig(#[from] serde_json::Error),
+    /// Error when creating the JS inspector
+    #[cfg(feature = "js-tracer")]
+    #[error("failed to create JS inspector: {0}")]
+    JsInspectorErr(#[from] JsInspectorError),
 }

--- a/tests/it/geth_js.rs
+++ b/tests/it/geth_js.rs
@@ -65,7 +65,7 @@ fn test_geth_jstracer_revert() {
     assert!(res.result.is_success());
 
     let (context, insp) = evm.ctx_inspector();
-    let result = insp.json_result(res, context.tx(), context.block(), context.db_ref()).unwrap();
+    let result = insp.json_result(&res, context.tx(), context.block(), context.db_ref()).unwrap();
 
     // successful operation
     assert!(!result["error"].as_bool().unwrap());
@@ -86,7 +86,7 @@ fn test_geth_jstracer_revert() {
     assert!(!res.result.is_success());
 
     let (context, insp) = evm.ctx_inspector();
-    let result = insp.json_result(res, context.tx(), context.block(), context.db_ref()).unwrap();
+    let result = insp.json_result(&res, context.tx(), context.block(), context.db_ref()).unwrap();
 
     // reverted operation
     assert!(result["error"].as_bool().unwrap());
@@ -173,6 +173,6 @@ fn test_geth_jstracer_proxy_contract() {
     assert!(res.result.is_success());
 
     let (context, insp) = evm.ctx_inspector();
-    let result = insp.json_result(res, context.tx(), context.block(), context.db_ref()).unwrap();
+    let result = insp.json_result(&res, context.tx(), context.block(), context.db_ref()).unwrap();
     assert_eq!(result, json!([{"event": "Transfer", "token": proxy_addr, "caller": deployer}]));
 }


### PR DESCRIPTION
Ref: https://github.com/paradigmxyz/revm-inspectors/issues/58

## Motivation

Currently `muxTracer` supports only built-in tracers. It should also support `JS tracers`.

Dependent on: https://github.com/alloy-rs/alloy/pull/2442