### PR TITLE
fix: js tracer behavior

### DIFF
--- a/src/tracing/js/mod.rs
+++ b/src/tracing/js/mod.rs
@@ -418,6 +418,7 @@ where
         let (stack, _stack_guard) = StackRef::new(&interp.stack);
         let evm_memory = interp.memory.borrow();
         let (memory, _memory_guard) = MemoryRef::new(evm_memory);
+        let active_call = self.active_call();
         let step = StepLog {
             stack,
             op: interp.bytecode.opcode().into(),
@@ -431,8 +432,8 @@ where
             contract: Contract {
                 caller: interp.input.caller_address,
                 contract: interp.input.target_address,
-                value: self.active_call().contract.value,
-                input: self.active_call().contract.input.clone(),
+                value: active_call.contract.value,
+                input: active_call.contract.input.clone(),
             },
         };
 
@@ -453,6 +454,7 @@ where
             let (stack, _stack_guard) = StackRef::new(&interp.stack);
             let mem = interp.memory.borrow();
             let (memory, _memory_guard) = MemoryRef::new(mem);
+            let active_call = self.active_call();
             let step = StepLog {
                 stack,
                 op: interp.bytecode.opcode().into(),
@@ -466,8 +468,8 @@ where
                 contract: Contract {
                     caller: interp.input.caller_address,
                     contract: interp.input.target_address,
-                    value: self.active_call().contract.value,
-                    input: self.active_call().contract.input.clone(),
+                    value: active_call.contract.value,
+                    input: active_call.contract.input.clone(),
                 },
             };
 


### PR DESCRIPTION
Closes https://github.com/paradigmxyz/revm-inspectors/issues/294 while retaining fix for https://github.com/paradigmxyz/reth/issues/13089

The idea is that in steps (aka logs) we want `contract.address` to always be the address of contract which storage is accessed (`target_address`). However, when dealing with delegatecall frames, `contract.address` should be set to the `bytecode_address` as it is marking the destination of delegatecall.

This means we can't just forward `active_call().contract` to steps anymore and need to re-construct the `Contract` value manually