### PR TITLE
chore(`deps`): bump revm to 24.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.0", default-features = false }
 alloy-primitives = { version = "1.0", default-features = false, features = [
     "map",
 ] }
-revm = { version = "23.1.0", default-features = false }
+revm = { version = "24.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
Bumps Revm to 24.0.0

New releases are out: https://github.com/bluealloy/revm/releases/tag/v74

Required for https://github.com/foundry-rs/foundry/issues/10557