### PR TITLE
chore: remove EOF leftovers

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -71,8 +71,6 @@ pub struct TracingInspectorConfig {
     pub exclude_precompile_calls: bool,
     /// Whether to record logs
     pub record_logs: bool,
-    /// Whether to record immediate bytes for opcodes.
-    pub record_immediate_bytes: bool,
 }
 
 impl TracingInspectorConfig {
@@ -87,7 +85,6 @@ impl TracingInspectorConfig {
             record_opcodes_filter: None,
             exclude_precompile_calls: false,
             record_logs: true,
-            record_immediate_bytes: true,
         }
     }
 
@@ -102,7 +99,6 @@ impl TracingInspectorConfig {
             exclude_precompile_calls: false,
             record_logs: false,
             record_opcodes_filter: None,
-            record_immediate_bytes: false,
         }
     }
 
@@ -119,7 +115,6 @@ impl TracingInspectorConfig {
             exclude_precompile_calls: true,
             record_logs: false,
             record_opcodes_filter: None,
-            record_immediate_bytes: false,
         }
     }
 
@@ -157,7 +152,6 @@ impl TracingInspectorConfig {
             exclude_precompile_calls: false,
             record_logs: false,
             record_opcodes_filter: None,
-            record_immediate_bytes: false,
         }
     }
 
@@ -239,7 +233,6 @@ impl TracingInspectorConfig {
         self.exclude_precompile_calls |= other.exclude_precompile_calls;
         self.record_logs |= other.record_logs;
         self.record_opcodes_filter = self.record_opcodes_filter.or(other.record_opcodes_filter);
-        self.record_immediate_bytes |= other.record_immediate_bytes;
         self
     }
 
@@ -341,17 +334,6 @@ impl TracingInspectorConfig {
     pub const fn set_record_logs(mut self, record_logs: bool) -> Self {
         self.record_logs = record_logs;
         self
-    }
-
-    /// Configure whether the tracer should record immediate bytes
-    pub const fn set_immediate_bytes(mut self, record_immediate_bytes: bool) -> Self {
-        self.record_immediate_bytes = record_immediate_bytes;
-        self
-    }
-
-    /// Enable recording of immediate bytes
-    pub const fn record_immediate_bytes(self) -> Self {
-        self.set_immediate_bytes(true)
     }
 
     /// If [OpcodeFilter] is configured, returns whether the given opcode should be recorded.

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -599,8 +599,6 @@ pub struct CallTraceStep {
     pub depth: u64,
     /// Program counter before step execution
     pub pc: usize,
-    /// Code section index before step execution
-    pub code_section_idx: usize,
     /// Opcode to be executed
     #[cfg_attr(feature = "serde", serde(with = "opcode_serde"))]
     pub op: OpCode,
@@ -631,8 +629,6 @@ pub struct CallTraceStep {
     ///
     /// This is set after the step was executed.
     pub status: InstructionResult,
-    /// Immediate bytes of the step
-    pub immediate_bytes: Option<Bytes>,
     /// Optional complementary decoded step data.
     pub decoded: Option<DecodedTraceStep>,
 }


### PR DESCRIPTION
Follow up of https://github.com/paradigmxyz/revm-inspectors/pull/299

Removes `record_immediate_bytes` and `code_section_idx` as added in https://github.com/paradigmxyz/revm-inspectors/pull/169

Undo's missed `ExtDelegateCall` from #299 : https://github.com/paradigmxyz/revm-inspectors/pull/156

Ref: https://github.com/paradigmxyz/revm-inspectors/pulls?q=is%3Apr+eof+is%3Aclosed