### PR TITLE
fix: record state diffs for vm tracer

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -139,6 +139,8 @@ impl TracingInspectorConfig {
             .set_steps(true)
             .set_stack_snapshots(StackSnapshotType::Pushes)
             .set_memory_snapshots(true)
+            // also need statediffs for recording altered storage in `VmExecutedOperation.store`
+            .set_state_diffs(true)
     }
 
     /// Returns a config for geth style traces.


### PR DESCRIPTION
the vmtracer needs state diffs for

https://github.com/alloy-rs/alloy/blob/c808022d571aaffb97a3429a0fdba6fc06e8f7aa/crates/rpc-types-trace/src/parity.rs#L659-L660

so that we enter here:

https://github.com/paradigmxyz/revm-inspectors/blob/1c0e405ad008453cded08b44a3cfa2ca611a6aa8/src/tracing/mod.rs#L502-L502 and record the `step-storage_change`

https://github.com/paradigmxyz/revm-inspectors/blob/1c0e405ad008453cded08b44a3cfa2ca611a6aa8/src/tracing/mod.rs#L507-L507