### PR TITLE
perf: optimize push_steps_on_stack to avoid temporary allocation

### DIFF
--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -217,21 +217,21 @@ impl CallTraceNode {
         stack: &mut VecDeque<CallTraceStepStackItem<'a>>,
     ) {
         let initial_len = stack.len();
-        
+
         // First, extend the stack with all steps in reverse order
         stack.extend(self.trace.steps.iter().rev().map(|step| CallTraceStepStackItem {
             trace_node: self,
             step,
             call_child_id: None,
         }));
-        
+
         // Then, iterate over the inserted range in reverse to set call_child_id values
         // Since we inserted in reverse order, we need to process from the end to maintain
         // the correct child_id assignment order
         let mut child_id = 0;
         for i in (initial_len..stack.len()).rev() {
             let step = stack[i].step;
-            
+
             // If the opcode is a call, set the child trace id
             if step.is_calllike_op() {
                 // The opcode of this step is a call but it's possible that this step resulted

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -230,14 +230,14 @@ impl CallTraceNode {
         // the correct child_id assignment order
         let mut child_id = 0;
         for i in (initial_len..stack.len()).rev() {
-            let step = stack[i].step;
+            let item = &mut stack[i];
 
             // If the opcode is a call, set the child trace id
-            if step.is_calllike_op() {
+            if item.step.is_calllike_op() {
                 // The opcode of this step is a call but it's possible that this step resulted
                 // in a revert or out of gas error in which case there's no actual child call executed and recorded: <https://github.com/paradigmxyz/reth/issues/3915>
                 if let Some(call_id) = self.children.get(child_id).copied() {
-                    stack[i].call_child_id = Some(call_id);
+                    item.call_child_id = Some(call_id);
                     child_id += 1;
                 }
             }


### PR DESCRIPTION
## Summary

Optimizes the `push_steps_on_stack` method to avoid creating a temporary vector allocation.

## Changes

The previous implementation would:
1. Call `call_step_stack()` which creates a temporary `Vec`
2. Reverse iterate over that vec and extend the deque

The new implementation:
1. Directly extends the deque with reversed steps (without computing `call_child_id`)
2. Iterates over the inserted range in reverse to set `call_child_id` values where needed



