### PR TITLE
perf: box CallTraceStep::storage_change

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -84,7 +84,7 @@ impl<'a> GethTraceBuilder<'a> {
             // Fill in memory and storage depending on the options
             if opts.is_storage_enabled() {
                 let contract_storage = storage.entry(step.contract).or_default();
-                if let Some(change) = step.storage_change {
+                if let Some(change) = &step.storage_change {
                     contract_storage.insert(change.key.into(), change.value.into());
                     log.storage = Some(contract_storage.clone());
                 }

--- a/src/tracing/builder/parity.rs
+++ b/src/tracing/builder/parity.rs
@@ -334,7 +334,7 @@ impl ParityTraceBuilder {
                     let mut instructions = Vec::with_capacity(current.trace.steps.len());
 
                     for step in &current.trace.steps {
-                        let maybe_sub_call = if step.is_calllike_op() {
+                        let maybe_sub_call = if step.is_call_like_op() {
                             sub_stack.pop_front().flatten()
                         } else {
                             None
@@ -377,7 +377,7 @@ impl ParityTraceBuilder {
         step: &CallTraceStep,
         maybe_sub_call: Option<VmTrace>,
     ) -> VmInstruction {
-        let maybe_storage = step.storage_change.map(|storage_change| StorageDelta {
+        let maybe_storage = step.storage_change.as_ref().map(|storage_change| StorageDelta {
             key: storage_change.key,
             val: storage_change.value,
         });
@@ -389,7 +389,7 @@ impl ParityTraceBuilder {
 
         let maybe_execution = Some(VmExecutedOperation {
             used: step.gas_remaining,
-            push: step.push_stack.clone().unwrap_or_default(),
+            push: step.push_stack.clone().unwrap_or_default().into(),
             mem: maybe_memory,
             store: maybe_storage,
         });

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -445,7 +445,7 @@ impl TracingInspector {
         let stack = if self.config.record_stack_snapshots.is_all()
             || self.config.record_stack_snapshots.is_full()
         {
-            Some(interp.stack.data().clone())
+            Some(interp.stack.data().as_slice().into())
         } else {
             None
         };
@@ -519,7 +519,7 @@ impl TracingInspector {
         {
             // this can potentially underflow if the stack is malformed
             let start = interp.stack.len().saturating_sub(step.op.outputs() as usize);
-            step.push_stack = Some(interp.stack.data()[start..].to_vec());
+            step.push_stack = Some(interp.stack.data()[start..].into());
         }
 
         let journal = context.journal_ref().journal();
@@ -545,7 +545,7 @@ impl TracingInspector {
                     };
                     let change =
                         StorageChange { key: *key, value, had_value: Some(*had_value), reason };
-                    Some(change)
+                    Some(Box::new(change))
                 }
                 _ => None,
             };

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         utils::gas_used,
     },
 };
-use alloc::vec::Vec;
+use alloc::{boxed::Box, vec::Vec};
 use core::{borrow::Borrow, mem};
 use revm::{
     bytecode::opcode::{self, OpCode},

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -144,14 +144,17 @@ impl CallTrace {
         self.decoded.get_or_insert_with(Default::default)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn decoded_label<'a>(&'a self, fallback: &'a str) -> &'a str {
         self.decoded.as_ref().and_then(|d| d.label.as_deref()).unwrap_or(fallback)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn decoded_call_data(&self) -> Option<&DecodedCallData> {
         self.decoded.as_ref()?.call_data.as_ref()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn decoded_return_data(&self) -> Option<&str> {
         self.decoded.as_ref()?.return_data.as_deref()
     }
@@ -211,10 +214,12 @@ impl CallLog {
         self.decoded.get_or_insert_with(Default::default)
     }
 
+    #[allow(dead_code)]
     pub(crate) fn decoded_name(&self) -> Option<&str> {
         self.decoded.as_deref()?.name.as_deref()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn decoded_params(&self) -> Option<&[(String, String)]> {
         self.decoded.as_deref()?.params.as_deref()
     }


### PR DESCRIPTION
Same as https://github.com/paradigmxyz/revm-inspectors/issues/324, plus a few nits.

Reduces the size of `CallTraceStep` from 336 to 216 bytes on 64-bit.
This is a gain overall because the vast majority of steps (>=95%) do not change storage.