### PR TITLE
chore: fix ensure `$root` is always an absolute path

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e -o pipefail
 
-root=$(dirname "$(dirname "$0")")
+root=$(dirname "$(dirname "$(realpath "$0")")")
 cmd=(git cliff --workdir "$root" --output "$root/CHANGELOG.md" "$@")
 
 if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
added `realpath` when calculating the root, so `$root` will always be an absolute path, no matter where or how the script is run.

p.s. this prevents errors with `git cliff --workdir` when the script is executed from a different directory.
