### PR TITLE
Fix return data in geth traces

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -76,9 +76,7 @@ impl<'a> GethTraceBuilder<'a> {
         main_trace_node.push_steps_on_stack(&mut step_stack);
 
         // Iterate over the steps inside the given trace
-        while let Some(CallTraceStepStackItem { trace_node, step, call_child_id }) =
-            step_stack.pop_back()
-        {
+        while let Some(CallTraceStepStackItem { step, call_child_id }) = step_stack.pop_back() {
             let mut log = step.convert_to_geth_struct_log(opts);
 
             // Fill in memory and storage depending on the options
@@ -91,7 +89,7 @@ impl<'a> GethTraceBuilder<'a> {
             }
 
             if opts.is_return_data_enabled() {
-                log.return_data = Some(trace_node.trace.output.clone());
+                log.return_data = Some(step.returndata.clone());
             }
 
             // Add step to geth trace

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -264,11 +264,13 @@ impl CallTraceNode {
         let initial_len = stack.len();
 
         // First, extend the stack with all steps in reverse order
-        stack.extend(self.trace.steps.iter().rev().map(|step| CallTraceStepStackItem {
-            trace_node: self,
-            step,
-            call_child_id: None,
-        }));
+        stack.extend(
+            self.trace
+                .steps
+                .iter()
+                .rev()
+                .map(|step| CallTraceStepStackItem { step, call_child_id: None }),
+        );
 
         // Then, iterate over the inserted range in reverse to set call_child_id values
         // Since we inserted in reverse order, we need to process from the end to maintain
@@ -602,8 +604,6 @@ impl From<CallKind> for CallType {
 }
 
 pub(crate) struct CallTraceStepStackItem<'a> {
-    /// The trace node that contains this step
-    pub(crate) trace_node: &'a CallTraceNode,
     /// The step that this stack item represents
     pub(crate) step: &'a CallTraceStep,
     /// The index of the child call in the CallArena if this step's opcode is a call


### PR DESCRIPTION
The Geth trace builder incorrectly sets the same `returnData` value for all opcode steps in a trace, 
using the final call output instead of the step-specific return data buffer state.

## Expected Behavior

Each opcode step should display the return data buffer state
at that specific point in execution.

## Actual Behavior

All opcode steps show the same returnData value - the final output of the entire
call. 

For example, in a Fibonacci contract call that returns 1, every single opcode
step shows:
"returnData": "0x0000000000000000000000000000000000000000000000000000000000000001"

