### PR TITLE
chore(deps): bump `revm` to `30.1.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth
-alloy-rpc-types-eth = { version = "1.0.28", default-features = false }
-alloy-rpc-types-trace = { version = "1.0.28", default-features = false }
-alloy-sol-types = { version = "1.2", default-features = false }
-alloy-primitives = { version = "1.2", default-features = false, features = [
+alloy-rpc-types-eth = { version = "1.0.38", default-features = false }
+alloy-rpc-types-trace = { version = "1.0.38", default-features = false }
+alloy-sol-types = { version = "1.4", default-features = false }
+alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
 revm = { version = "30.1.0", default-features = false }


### PR DESCRIPTION
Bumps revm to 30.1.0

Ref: https://github.com/foundry-rs/foundry/issues/12075