### PR TITLE
fix: dont filter out created+selfdestruct in pre

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -319,7 +319,15 @@ impl<'a> GethTraceBuilder<'a> {
 
             // determine the change type
             let pre_change = if changed_acc.is_created() {
-                AccountChangeKind::Create
+                // if the account was created _and_ selfdestructed we need to treat it as modified,
+                // so that it is retained later in `diff_traces`
+                // See <https://etherscan.io/tx/0x391f4b6a382d3bcc3120adc2ea8c62003e604e487d97281129156fd284a1a89d>
+                // <https://github.com/paradigmxyz/reth/issues/19703#issuecomment-3527067849>
+                if changed_acc.is_selfdestructed() {
+                    AccountChangeKind::Modify
+                } else {
+                    AccountChangeKind::Create
+                }
             } else {
                 AccountChangeKind::Modify
             };


### PR DESCRIPTION
should close this one https://github.com/paradigmxyz/reth/issues/19703

previously we were yeeting them from pre here:

https://github.com/paradigmxyz/revm-inspectors/blob/cbf97c9947f02e07dbe0c5e27e32fbb3d205114d/src/tracing/builder/geth.rs#L378-L379