### PR TITLE
fix: use pre code if hash matches

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -297,10 +297,10 @@ impl<'a> GethTraceBuilder<'a> {
                 changed_acc.info.balance,
                 code_enabled
                     .then(|| {
-                        // Note: the changed account from the state output always holds the code
                         if changed_acc.info.code_hash == db_acc.code_hash {
                             pre_code.clone()
                         } else {
+                            // Note: the changed account from the state output always holds the code
                             changed_acc.info.code.as_ref().map(|code| code.original_bytes())
                         }
                     })


### PR DESCRIPTION
this fixes an issue where we would return diffs like

```
                "post": {
                    "0x093f6c270ac22ec240f0c6fd7414ea774ca8d3e5": {},
                    "0x2641c2ded63a0c640629f5edf1189e0f53c06561": {},
```

for `0x91b066df39661db7bcca1cb8bb8afd11816414408d44cbfcf6144f440d5dfe3b` ref https://github.com/paradigmxyz/reth/issues/19703

however nothing changed in the account here and these should have been filtered out via:

https://github.com/paradigmxyz/revm-inspectors/blob/f7503520888efc11eac3142fe7d611c519811b25/src/tracing/builder/geth.rs#L349-L349

and cleared from post via:

https://github.com/alloy-rs/alloy/blob/35e20437670d987680a6715bcc173f3d357f8254/crates/rpc-types-trace/src/geth/pre_state.rs#L188-L201

the reason why this didn't work is because:

the code can be None here which would make retain_change not remove the values

```
          "result": {
                "post": {
                    "0x093f6c270ac22ec240f0c6fd7414ea774ca8d3e5": {},
                    "0x2641c2ded63a0c640629f5edf1189e0f53c06561": {},
                    "0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5": {
                        "balance": "0xc87826afc2b88254"
                    },
                    "0xbf5495efe5db9ce00f80364c8b423567e58d2110": {
                        "storage": {
                            "0x0000000000000000000000000000000000000000000000000000000000000035": "0x000000000000000000000000000000000000000000004b7b53b759cac06bc3b2",
                            "0xec8c572bc2e66bfe14376dece39002d6d97d311020c59bc23a93016013e92439": "0x0000000000000000000000000000000000000000000000000f294a8cb09ad9cb"
                        }
                    },
                    "0xbfe474605fb7f1cf3693a3f21af2e329f7222462": {
                        "balance": "0x269f4a55a240465",
                        "nonce": 5
                    },
                    "0xf2f305d14dcd8aaef887e0428b3c9534795d0d60": {
                        "balance": "0xe984e9959d534d3cdf"
                    }
                },
                "pre": {
                    "0x093f6c270ac22ec240f0c6fd7414ea774ca8d3e5": {
                        "balance": "0x1ea3abe47d76b5e00",
                        "code": "..",
                        "nonce": 1
                    },
                    "0x2641c2ded63a0c640629f5edf1189e0f53c06561": {
                        "balance": "0x1cb3ca6ff6dc41400",
                        "code": "..",
                        "nonce": 1
                    },
                    "0x95222290dd7278aa3ddd389cc1e1d165cc4bafe5": {
                        "balance": "0xc8781d351add1146",
                        "nonce": 797368
                    },
                    "0xbf5495efe5db9ce00f80364c8b423567e58d2110": {
                        "balance": "0x0",
                        "code": "...",
                        "nonce": 1,
                        "storage": {
                            "0x0000000000000000000000000000000000000000000000000000000000000035": "0x000000000000000000000000000000000000000000004b7b448e0f3e0fd0e9e7"
                        }
                    },
                    "0xbfe474605fb7f1cf3693a3f21af2e329f7222462": {
                        "balance": "0x11d7cc57700ae2ed",
                        "nonce": 4
                    },
                    "0xf2f305d14dcd8aaef887e0428b3c9534795d0d60": {
                        "balance": "0xe975a599714e5f3cdf",
                        "code": "...",
                        "nonce": 1
                    }
                }
            },

```

we can always use the precode here if the hashes match