### PR TITLE
feat: add features for skipping ser/de of call trace steps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,12 @@ std = [
     "thiserror/std",
 ]
 serde = ["dep:serde", "revm/serde"]
+serde-skip-trace-steps = [
+    "skip-trace-steps-ser",
+    "skip-trace-steps-deser",
+]
+skip-trace-steps-ser = []
+skip-trace-steps-deser = []
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -99,6 +99,11 @@ pub struct CallTrace {
     /// The final status of the call.
     pub status: Option<InstructionResult>,
     /// Opcode-level execution steps.
+    #[cfg_attr(all(feature = "serde", feature = "skip-trace-steps-ser"), serde(skip_serializing))]
+    #[cfg_attr(
+        all(feature = "serde", feature = "skip-trace-steps-deser"),
+        serde(skip_deserializing)
+    )]
     pub steps: Vec<CallTraceStep>,
     /// Optional complementary decoded call data.
     pub decoded: Option<Box<DecodedCallTrace>>,


### PR DESCRIPTION
Serializing `CallTraceStep`s is too verbose, one `CallTraceArean` for a single trace of a heavy transaction can lead to huge data.

E.g.: A GMX order execution transaction's `CallTraceArena` with steps exceeds 2GB(without steps it is 0.6mb) when serialized to JSON. And most of that is because of the steps getting serialized too.