### PR TITLE
feat(edge_cov): add CmpLog-style comparison operand tracking

### DIFF
--- a/src/edge_cov.rs
+++ b/src/edge_cov.rs
@@ -17,14 +17,34 @@ use revm::{
 // and precision (less collisions).
 const MAX_EDGE_COUNT: usize = 65536;
 
+// Maximum number of comparison operand pairs to track (for CmpLog-style feedback).
+const MAX_CMP_LOG_ENTRIES: usize = 1024;
+
+/// A comparison operand pair captured during execution.
+/// Used for CmpLog-style guided fuzzing to help solve constraints.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CmpOperands {
+    /// First operand of the comparison
+    pub op1: U256,
+    /// Second operand of the comparison
+    pub op2: U256,
+    /// Program counter where the comparison occurred
+    pub pc: usize,
+}
+
 /// An `Inspector` that tracks [edge coverage](https://clang.llvm.org/docs/SanitizerCoverage.html#edge-coverage).
 /// Covered edges will not wrap to zero e.g. a loop edge hit more than 255 will still be retained.
+///
+/// Also tracks comparison operands (CmpLog-style) to enable constraint solving during fuzzing.
 // see https://github.com/AFLplusplus/AFLplusplus/blob/5777ceaf23f48ae4ceae60e4f3a79263802633c6/instrumentation/afl-llvm-pass.so.cc#L810-L829
 #[derive(Clone)]
 pub struct EdgeCovInspector {
     /// Map of hitcounts that can be diffed against to determine if new coverage was reached.
     hitcount: Vec<u8>,
     hash_builder: DefaultHashBuilder,
+    /// Comparison operand log for CmpLog-style guided fuzzing.
+    /// Stores operands from EQ, LT, GT, SLT, SGT operations.
+    cmp_log: Vec<CmpOperands>,
 }
 
 impl fmt::Debug for EdgeCovInspector {
@@ -36,12 +56,17 @@ impl fmt::Debug for EdgeCovInspector {
 impl EdgeCovInspector {
     /// Create a new `EdgeCovInspector` with `MAX_EDGE_COUNT` size.
     pub fn new() -> Self {
-        Self { hitcount: vec![0; MAX_EDGE_COUNT], hash_builder: DefaultHashBuilder::default() }
+        Self {
+            hitcount: vec![0; MAX_EDGE_COUNT],
+            hash_builder: DefaultHashBuilder::default(),
+            cmp_log: Vec::with_capacity(MAX_CMP_LOG_ENTRIES),
+        }
     }
 
-    /// Reset the hitcount to zero.
+    /// Reset the hitcount to zero and clear comparison log.
     pub fn reset(&mut self) {
         self.hitcount.fill(0);
+        self.cmp_log.clear();
     }
 
     /// Get an immutable reference to the hitcount.
@@ -49,9 +74,19 @@ impl EdgeCovInspector {
         self.hitcount.as_slice()
     }
 
+    /// Get an immutable reference to the comparison operand log.
+    pub fn get_cmp_log(&self) -> &[CmpOperands] {
+        self.cmp_log.as_slice()
+    }
+
     /// Consume the inspector and take ownership of the hitcount.
     pub fn into_hitcount(self) -> Vec<u8> {
         self.hitcount
+    }
+
+    /// Consume the inspector and return both hitcount and cmp_log.
+    pub fn into_parts(self) -> (Vec<u8>, Vec<CmpOperands>) {
+        (self.hitcount, self.cmp_log)
     }
 
     /// Mark the edge, H(address, pc, jump_dest), as hit.
@@ -64,6 +99,13 @@ impl EdgeCovInspector {
         // so it must be modulo the maximum edge count.
         let edge_id = (hasher.finish() % MAX_EDGE_COUNT as u64) as usize;
         self.hitcount[edge_id] = self.hitcount[edge_id].checked_add(1).unwrap_or(1);
+    }
+
+    /// Store comparison operands for CmpLog-style guided fuzzing.
+    fn store_cmp(&mut self, pc: usize, op1: U256, op2: U256) {
+        if self.cmp_log.len() < MAX_CMP_LOG_ENTRIES {
+            self.cmp_log.push(CmpOperands { op1, op2, pc });
+        }
     }
 
     #[cold]
@@ -98,6 +140,30 @@ impl EdgeCovInspector {
             }
         }
     }
+
+    /// Handle comparison opcodes to log operands for CmpLog-style guidance.
+    #[cold]
+    fn do_cmp_step(&mut self, interp: &mut Interpreter) {
+        let current_pc = interp.bytecode.pc();
+
+        match interp.bytecode.opcode() {
+            opcode::EQ | opcode::LT | opcode::GT | opcode::SLT | opcode::SGT => {
+                // These opcodes compare stack[0] and stack[1]
+                if let (Ok(op1), Ok(op2)) = (interp.stack.peek(0), interp.stack.peek(1)) {
+                    self.store_cmp(current_pc, op1, op2);
+                }
+            }
+            opcode::ISZERO => {
+                // ISZERO compares stack[0] with 0
+                if let Ok(op1) = interp.stack.peek(0) {
+                    self.store_cmp(current_pc, op1, U256::ZERO);
+                }
+            }
+            _ => {
+                // no-op
+            }
+        }
+    }
 }
 
 impl Default for EdgeCovInspector {
@@ -109,8 +175,16 @@ impl Default for EdgeCovInspector {
 impl<CTX> Inspector<CTX> for EdgeCovInspector {
     #[inline]
     fn step(&mut self, interp: &mut Interpreter, _context: &mut CTX) {
-        if matches!(interp.bytecode.opcode(), opcode::JUMP | opcode::JUMPI) {
+        let op = interp.bytecode.opcode();
+        if matches!(op, opcode::JUMP | opcode::JUMPI) {
             self.do_step(interp);
+        }
+        // Track comparison operands for CmpLog-style guidance
+        if matches!(
+            op,
+            opcode::EQ | opcode::LT | opcode::GT | opcode::SLT | opcode::SGT | opcode::ISZERO
+        ) {
+            self.do_cmp_step(interp);
         }
     }
 }

--- a/tests/it/edge_cov.rs
+++ b/tests/it/edge_cov.rs
@@ -15,7 +15,7 @@ use revm::{
     Context, DatabaseCommit, InspectEvm, MainBuilder, MainContext,
 };
 use revm_inspectors::{
-    edge_cov::EdgeCovInspector,
+    edge_cov::{CmpOperands, EdgeCovInspector},
     tracing::{TracingInspector, TracingInspectorConfig},
 };
 
@@ -108,4 +108,147 @@ fn test_edge_coverage() {
     assert_eq!(counts[counts.len() - 1], 255);
     assert_eq!(counts[counts.len() - 2], 255);
     assert_eq!(counts.iter().filter(|&x| *x != 0).count(), 13);
+}
+
+#[test]
+fn test_cmp_log_basic() {
+    /*
+    contract CmpTest {
+        function compare(uint256 a, uint256 b) external pure returns (bool) {
+            return a == b;
+        }
+    }
+    */
+    // Compiled bytecode from Solidity 0.8.33
+    let code = hex!("6080604052348015600e575f5ffd5b5061012e8061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c8063f360234c14602a575b5f5ffd5b60406004803603810190603c91906092565b6054565b604051604b919060e1565b60405180910390f35b5f818314905092915050565b5f5ffd5b5f819050919050565b6074816064565b8114607d575f5ffd5b50565b5f81359050608c81606d565b92915050565b5f5f6040838503121560a55760a46060565b5b5f60b0858286016080565b925050602060bf858286016080565b9150509250929050565b5f8115159050919050565b60db8160c9565b82525050565b5f60208201905060f25f83018460d4565b9291505056fea26469706673582212201aa69cc881fa3f0ed6fd2a2d01f2a9efd71de5f7aebe97a5904f3177eb12c99764736f6c63430008210033");
+    let deployer = Address::ZERO;
+
+    let ctx = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.spec = SpecId::CANCUN)
+        .with_db(CacheDB::new(EmptyDB::default()));
+
+    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
+    let mut evm = ctx.build_mainnet_with_inspector(&mut insp);
+
+    // Create contract
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller: deployer,
+            gas_limit: 1000000,
+            kind: TransactTo::Create,
+            data: code.into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let addr = match res.result {
+        ExecutionResult::Success { output, .. } => match output {
+            Output::Create(_, addr) => addr.unwrap(),
+            _ => panic!("Create failed"),
+        },
+        _ => panic!("Execution failed"),
+    };
+    evm.ctx().db_mut().commit(res.state);
+
+    let acc = evm.ctx().db_mut().load_account(deployer).unwrap();
+    acc.info.balance = U256::from(u64::MAX);
+
+    // Call compare(42, 100)
+    let tx = TxEnv {
+        caller: deployer,
+        gas_limit: 100000000,
+        kind: TransactTo::Call(addr),
+        nonce: 1,
+        // 'cast calldata "compare(uint256,uint256)" 42 100'
+        data: hex!("f360234c000000000000000000000000000000000000000000000000000000000000002a0000000000000000000000000000000000000000000000000000000000000064")
+            .into(),
+        ..Default::default()
+    };
+
+    let insp = EdgeCovInspector::new();
+    let mut evm = evm.with_inspector(insp);
+    let res = evm.inspect_tx(tx).unwrap();
+    assert!(res.result.is_success());
+
+    // Check that CmpLog captured some comparisons
+    let cmp_log = evm.inspector().get_cmp_log();
+    assert!(!cmp_log.is_empty(), "CmpLog should capture comparison operands");
+
+    // Should have captured the comparison values 42 and 100
+    let has_42 = cmp_log.iter().any(|cmp| cmp.op1 == U256::from(42) || cmp.op2 == U256::from(42));
+    let has_100 = cmp_log.iter().any(|cmp| cmp.op1 == U256::from(100) || cmp.op2 == U256::from(100));
+    assert!(has_42 || has_100, "CmpLog should capture operand values from comparison");
+}
+
+#[test]
+fn test_cmp_log_into_parts() {
+    let inspector = EdgeCovInspector::new();
+
+    // Verify initial state
+    assert!(inspector.get_cmp_log().is_empty());
+    assert!(inspector.get_hitcount().iter().all(|&x| x == 0));
+
+    // Test into_parts
+    let (hitcount, cmp_log) = inspector.into_parts();
+    assert_eq!(hitcount.len(), 65536); // MAX_EDGE_COUNT
+    assert!(cmp_log.is_empty());
+}
+
+#[test]
+fn test_cmp_log_reset() {
+    /*
+    contract LtTest {
+        function lessThan(uint256 a, uint256 b) external pure returns (bool) {
+            return a < b;
+        }
+    }
+    */
+    let code = hex!("6080604052348015600f57600080fd5b5060043610601c5760003560e01c8063021c06c0146021575b600080fd5b6031603336600460505650565b60405190151581526020015b60405180910390f35b60006020828403121560615750565b5091905056");
+    let deployer = Address::ZERO;
+
+    let ctx = Context::mainnet()
+        .modify_cfg_chained(|cfg| cfg.spec = SpecId::LONDON)
+        .with_db(CacheDB::new(EmptyDB::default()));
+
+    let insp = EdgeCovInspector::new();
+    let mut evm = ctx.build_mainnet_with_inspector(insp);
+
+    // Just run a simple transaction to potentially capture some comparisons
+    let _ = evm.inspect_tx(TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Create,
+        data: code.into(),
+        ..Default::default()
+    });
+
+    // Reset and verify both hitcount and cmp_log are cleared
+    evm.inspector().reset();
+    assert!(evm.inspector().get_hitcount().iter().all(|&x| x == 0));
+    assert!(evm.inspector().get_cmp_log().is_empty());
+}
+
+#[test]
+fn test_cmp_operands_struct() {
+    // Test CmpOperands struct
+    let cmp = CmpOperands {
+        op1: U256::from(123),
+        op2: U256::from(456),
+        pc: 42,
+    };
+
+    assert_eq!(cmp.op1, U256::from(123));
+    assert_eq!(cmp.op2, U256::from(456));
+    assert_eq!(cmp.pc, 42);
+
+    // Test Default
+    let default_cmp = CmpOperands::default();
+    assert_eq!(default_cmp.op1, U256::ZERO);
+    assert_eq!(default_cmp.op2, U256::ZERO);
+    assert_eq!(default_cmp.pc, 0);
+
+    // Test Clone
+    let cloned = cmp.clone();
+    assert_eq!(cloned.op1, cmp.op1);
+    assert_eq!(cloned.op2, cmp.op2);
+    assert_eq!(cloned.pc, cmp.pc);
 }


### PR DESCRIPTION
## Summary

Add comparison operand logging to `EdgeCovInspector` for CmpLog-style guided fuzzing. This captures operands from EQ, LT, GT, SLT, SGT, and ISZERO opcodes to help fuzzers solve comparison constraints.

## Motivation

Coverage-guided fuzzers struggle with tight constraints like `a == 61 * b` because they sample parameters independently. By capturing the actual comparison operands at runtime, fuzzers can:
- Add observed values to their dictionary
- Synthesize related values (e.g., divide by common multipliers)
- Generate inputs that satisfy magic byte/number comparisons

This is inspired by [AFL++'s CmpLog feature](https://github.com/AFLplusplus/AFLplusplus/blob/stable/instrumentation/README.cmplog.md).

## Changes

- Add `CmpOperands` struct to store comparison operand pairs with PC
- Add `cmp_log` field to `EdgeCovInspector`
- Add `get_cmp_log()` and `into_parts()` accessor methods
- Modify `reset()` to clear cmp_log alongside hitcount
- Add `store_cmp()` and `do_cmp_step()` for capturing comparison operands
- Track comparison opcodes (EQ, LT, GT, SLT, SGT, ISZERO) in `step()` inspector method

## Testing

Added 4 unit tests:
- `test_cmp_log_basic` - Verifies CmpLog captures comparison operands from a real contract
- `test_cmp_log_into_parts` - Tests the `into_parts()` method
- `test_cmp_log_reset` - Verifies `reset()` clears both hitcount and cmp_log  
- `test_cmp_operands_struct` - Tests CmpOperands struct creation, Default, Clone

## Usage

```rust
let inspector = EdgeCovInspector::new();
// ... run EVM with inspector ...

// Get comparison operands for dictionary enrichment
let cmp_log = inspector.get_cmp_log();
for cmp in cmp_log {
    println!("Comparison at PC {}: {} vs {}", cmp.pc, cmp.op1, cmp.op2);
}

// Or consume both hitcount and cmp_log
let (hitcount, cmp_log) = inspector.into_parts();
```
