### PR TITLE
tip1016: revm state-gas integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "44a4233dbce8c283421cb568051fbba9d37894b0" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "a357a608d3ac327326abaaf70b1ec1a5d2c57542" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,6 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm.git", branch = "rakita/state-gas" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm.git", rev = "1e1d64d54" }
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "94e03057f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm.git", rev = "94e03057f" }
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "8891655bb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm.git", branch = "rakita/state-gas" }
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "eef4f2af" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "revm-inspectors"
 description = "Revm inspector implementations"
-version = "0.36.1"
+version = "0.37.0"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "a357a608d3ac327326abaaf70b1ec1a5d2c57542" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "d7267ab182ea0ae2f0d8b870237a306be836b410" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm.git", rev = "eef4f2af" }
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "712dac7a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm.git", rev = "8891655bb" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "44a4233dbce8c283421cb568051fbba9d37894b0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,4 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm.git", rev = "712dac7a" }
+revm = { git = "https://github.com/bluealloy/revm.git", rev = "1e1d64d54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "36.0.0", default-features = false }
+revm = { version = "37.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"
@@ -67,5 +67,3 @@ std = [
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "d7267ab182ea0ae2f0d8b870237a306be836b410" }

--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -223,7 +223,7 @@ impl DebugInspector {
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
                 inspector.set_transaction_caller(tx_env.caller());
-                inspector.geth_builder().geth_call_traces(*config, res.result.gas_used()).into()
+                inspector.geth_builder().geth_call_traces(*config, res.result.tx_gas_used()).into()
             }
             Self::PreStateTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
@@ -252,7 +252,7 @@ impl DebugInspector {
                 inspector.set_transaction_caller(tx_env.caller());
                 inspector
                     .geth_builder()
-                    .geth_erc7562_traces(config.clone(), res.result.gas_used(), db)
+                    .geth_erc7562_traces(config.clone(), res.result.tx_gas_used(), db)
                     .into()
             }
             Self::Default(inspector, config) => {
@@ -261,7 +261,7 @@ impl DebugInspector {
                 inspector
                     .geth_builder()
                     .geth_traces(
-                        res.result.gas_used(),
+                        res.result.tx_gas_used(),
                         res.result.output().unwrap_or_default().clone(),
                         *config,
                     )

--- a/src/tracing/js/mod.rs
+++ b/src/tracing/js/mod.rs
@@ -269,7 +269,7 @@ impl JsInspector {
         let ResultAndState { result, state } = res;
         let (db, _db_guard) = EvmDbRef::new(&state, db);
 
-        let gas_used = result.gas_used();
+        let gas_used = result.tx_gas_used();
         let mut to = None;
         let mut output_bytes = None;
         let mut error = None;
@@ -445,7 +445,7 @@ where
         let (memory, _memory_guard) = MemoryRef::new(evm_memory);
         let active_call = self.active_call();
 
-        let gas_spent = interp.gas.spent();
+        let gas_spent = interp.gas.total_gas_spent();
         let step = StepLog {
             stack,
             op: interp.bytecode.opcode().into(),
@@ -491,7 +491,7 @@ where
             let mem = interp.memory.borrow();
             let (memory, _memory_guard) = MemoryRef::new(mem);
             let active_call = self.active_call();
-            let gas_spent = interp.gas.spent();
+            let gas_spent = interp.gas.total_gas_spent();
 
             let step = StepLog {
                 stack,
@@ -563,7 +563,7 @@ where
     fn call_end(&mut self, _context: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
         if self.can_call_exit() {
             let frame_result = FrameResult {
-                gas_used: outcome.result.gas.spent(),
+                gas_used: outcome.result.gas.total_gas_spent(),
                 output: outcome.result.output.clone(),
                 error: utils::fmt_error_msg(outcome.result.result, TraceStyle::Geth),
             };
@@ -609,7 +609,7 @@ where
     ) {
         if self.can_call_exit() {
             let frame_result = FrameResult {
-                gas_used: outcome.result.gas.spent(),
+                gas_used: outcome.result.gas.total_gas_spent(),
                 output: outcome.result.output.clone(),
                 error: None,
             };

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -394,7 +394,7 @@ impl TracingInspector {
         let trace_idx = self.pop_trace_idx();
         let trace = &mut self.traces.arena[trace_idx].trace;
 
-        trace.gas_used = gas.spent();
+        trace.gas_used = gas.total_gas_spent();
         trace.gas_refund_counter = gas.refunded().max(0) as u64;
 
         trace.status = Some(result);
@@ -467,7 +467,7 @@ impl TracingInspector {
 
         let gas_used = gas_used(
             interp.runtime_flag.spec_id(),
-            interp.gas.spent(),
+            interp.gas.total_gas_spent(),
             interp.gas.refunded() as u64,
         );
 

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -118,7 +118,7 @@ impl MuxInspector {
                     if let Some(inspector) = &self.tracing {
                         inspector
                             .geth_builder()
-                            .geth_call_traces(*call_config, result.result.gas_used())
+                            .geth_call_traces(*call_config, result.result.tx_gas_used())
                             .into()
                     } else {
                         continue;

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -80,9 +80,9 @@ fn test_geth_calltracer_logs() {
     assert!(res.result.is_success());
 
     let call_frame = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(CallConfig::default().with_log(), res.result.gas_used());
+        .geth_call_traces(CallConfig::default().with_log(), res.result.tx_gas_used());
 
     // top-level call succeeded, no log and three subcalls
     assert_eq!(call_frame.calls.len(), 3);
@@ -384,9 +384,9 @@ fn test_geth_calltracer_top_call_reverting() {
     // Get call traces with only_top_call = true
     let call_config_top = CallConfig { only_top_call: Some(true), with_log: Some(false) };
     let call_frame_top = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(call_config_top, res.result.gas_used());
+        .geth_call_traces(call_config_top, res.result.tx_gas_used());
 
     // With only_top_call = true, we should not see any subcalls in the trace
     assert_eq!(call_frame_top.calls.len(), 0, "Should have no subcalls when only_top_call is true");
@@ -417,9 +417,9 @@ fn test_geth_calltracer_top_call_reverting() {
     // Get call traces with only_top_call = false (default)
     let call_config_all = CallConfig { only_top_call: Some(false), with_log: Some(false) };
     let call_frame_all = insp2
-        .with_transaction_gas_used(res2.result.gas_used())
+        .with_transaction_gas_used(res2.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(call_config_all, res2.result.gas_used());
+        .geth_call_traces(call_config_all, res2.result.tx_gas_used());
 
     // nestedEmitWithFailureAfterNestedEmit calls doubleNestedEmitWithSuccess which calls
     // nestedEmitWithSuccess So we should see nested calls when only_top_call = false
@@ -472,9 +472,9 @@ fn test_geth_calltracer_nested_revert() {
     // Get call traces with only_top_call = true
     let call_config_top = CallConfig { only_top_call: Some(true), with_log: Some(false) };
     let call_frame_top = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(call_config_top, res.result.gas_used());
+        .geth_call_traces(call_config_top, res.result.tx_gas_used());
 
     // With only_top_call = true, we should not see the subcall to nestedEmitWithFailure
     assert_eq!(call_frame_top.calls.len(), 0, "Should have no subcalls when only_top_call is true");
@@ -505,9 +505,9 @@ fn test_geth_calltracer_nested_revert() {
     // Get call traces with only_top_call = false
     let call_config_all = CallConfig { only_top_call: Some(false), with_log: Some(false) };
     let call_frame_all = insp2
-        .with_transaction_gas_used(res2.result.gas_used())
+        .with_transaction_gas_used(res2.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(call_config_all, res2.result.gas_used());
+        .geth_call_traces(call_config_all, res2.result.tx_gas_used());
 
     // nestedRevert calls nestedEmitWithFailure, so we should see one subcall
     assert_eq!(call_frame_all.calls.len(), 1, "Should have one subcall to nestedEmitWithFailure");
@@ -543,9 +543,9 @@ fn test_geth_calltracer_nested_revert() {
     // Get call traces with logs enabled and only_top_call = false
     let call_config_logs = CallConfig { only_top_call: Some(true), with_log: Some(true) };
     let top_call = insp3
-        .with_transaction_gas_used(res3.result.gas_used())
+        .with_transaction_gas_used(res3.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(call_config_logs, res3.result.gas_used());
+        .geth_call_traces(call_config_logs, res3.result.tx_gas_used());
 
     // nestedEmitWithFailure emits a log before reverting, but since it reverts, the log should not
     // be included
@@ -597,7 +597,7 @@ fn test_geth_prestate_disable_code_in_diff_mode() {
     assert!(res.result.is_success());
 
     let frame = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
         .geth_prestate_traces(&res, &prestate_config_no_code, db)
         .unwrap();
@@ -655,7 +655,7 @@ fn test_geth_prestate_disable_code_in_diff_mode() {
     assert!(res2.result.is_success());
 
     let frame2 = insp2
-        .with_transaction_gas_used(res2.result.gas_used())
+        .with_transaction_gas_used(res2.result.tx_gas_used())
         .geth_builder()
         .geth_prestate_traces(&res2, &prestate_config_with_code, db2)
         .unwrap();
@@ -732,7 +732,7 @@ fn test_geth_calltracer_null_bytes_revert_reason_omitted() {
         .unwrap();
 
     let call_config = CallConfig::default();
-    let call_frame = insp.geth_builder().geth_call_traces(call_config, res.result.gas_used());
+    let call_frame = insp.geth_builder().geth_call_traces(call_config, res.result.tx_gas_used());
 
     assert!(call_frame.error.is_some(), "Call should have an error");
 
@@ -822,7 +822,7 @@ fn test_geth_prestate_diff_selfdestruct(spec_id: SpecId) {
     // Get the prestate diff traces
     let insp = evm.into_inspector();
     let frame = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
         .geth_prestate_traces(&res, &prestate_config, db)
         .unwrap();

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -913,9 +913,9 @@ fn test_geth_calltracer_logs_eip7708() {
     assert!(res.result.is_success(), "Transaction should succeed: {res:#?}");
 
     let call_frame = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(CallConfig::default().with_log(), res.result.gas_used());
+        .geth_call_traces(CallConfig::default().with_log(), res.result.tx_gas_used());
 
     // The top-level call should have one subcall (the CALL to ecrecover precompile).
     // Under AMSTERDAM with value transfer, the subcall to the precompile should have
@@ -999,9 +999,9 @@ fn test_geth_calltracer_logs_address_regular() {
     assert!(res.result.is_success(), "Transaction should succeed: {res:#?}");
 
     let call_frame = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(CallConfig::default().with_log(), res.result.gas_used());
+        .geth_call_traces(CallConfig::default().with_log(), res.result.tx_gas_used());
 
     // The top-level call should have one log with the contract address as the emitter.
     assert_eq!(call_frame.logs.len(), 1, "Expected exactly one log");
@@ -1082,9 +1082,9 @@ fn test_geth_calltracer_logs_delegatecall() {
     assert!(res.result.is_success(), "Transaction should succeed: {res:#?}");
 
     let call_frame = insp
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
-        .geth_call_traces(CallConfig::default().with_log(), res.result.gas_used());
+        .geth_call_traces(CallConfig::default().with_log(), res.result.tx_gas_used());
 
     // The top-level call is to the proxy. It should have one subcall (the DELEGATECALL).
     assert_eq!(call_frame.calls.len(), 1, "Expected one subcall (DELEGATECALL)");

--- a/tests/it/repro/prestate.rs
+++ b/tests/it/repro/prestate.rs
@@ -57,7 +57,7 @@ fn test_prestate_tracer_selfdestruct() {
 
     // Get the prestate trace
     let frame = inspector
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
         .geth_prestate_traces(&res, &prestate_config, db)
         .unwrap();
@@ -96,7 +96,7 @@ fn test_prestate_tracer_selfdestruct_diff_mode() {
     assert!(res.result.is_success(), "tx failed: {:?}", res.result);
 
     let frame = inspector
-        .with_transaction_gas_used(res.result.gas_used())
+        .with_transaction_gas_used(res.result.tx_gas_used())
         .geth_builder()
         .geth_prestate_traces(&res, &prestate_config, db)
         .unwrap();


### PR DESCRIPTION
## Summary
- Update revm rev to `e3223d5b38f7affb901601ed917fa7cdc466be74` (rakita/state-gas branch) for TIP-1016 dual-limit gas accounting

## Test plan
- [x] `cargo check` compiles clean
- [x] `cargo +nightly clippy` passes
- [x] `cargo nextest run` — all 37 tests pass