### PR TITLE
feat: add set_transaction_caller and set_transaction_target

### DIFF
--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -222,6 +222,7 @@ impl DebugInspector {
             Self::FourByte(inspector) => FourByteFrame::from(&*inspector).into(),
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector.set_transaction_caller(tx_env.caller());
                 inspector.geth_builder().geth_call_traces(*config, res.result.gas_used()).into()
             }
             Self::PreStateTracer(inspector, config) => {
@@ -239,6 +240,7 @@ impl DebugInspector {
                 .into(),
             Self::FlatCallTracer(inspector) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector.set_transaction_caller(tx_env.caller());
                 inspector
                     .clone()
                     .into_parity_builder()
@@ -247,6 +249,7 @@ impl DebugInspector {
             }
             Self::Erc7562Tracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector.set_transaction_caller(tx_env.caller());
                 inspector
                     .geth_builder()
                     .geth_erc7562_traces(config.clone(), res.result.gas_used(), db)
@@ -254,6 +257,7 @@ impl DebugInspector {
             }
             Self::Default(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
+                inspector.set_transaction_caller(tx_env.caller());
                 inspector
                     .geth_builder()
                     .geth_traces(

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -241,17 +241,6 @@ impl TracingInspector {
         }
     }
 
-    /// Manually set the target address of the root trace.
-    ///
-    /// This is useful for custom transaction types (e.g. account abstraction batches) where the
-    /// EVM's call entry point may not reflect the actual transaction target.
-    #[inline]
-    pub fn set_transaction_target(&mut self, target: Address) {
-        if let Some(node) = self.traces.arena.first_mut() {
-            node.trace.address = target;
-        }
-    }
-
     /// Consumes the Inspector and returns a [ParityTraceBuilder].
     #[inline]
     pub fn into_parity_builder(self) -> ParityTraceBuilder {

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -230,6 +230,28 @@ impl TracingInspector {
         self
     }
 
+    /// Manually set the caller address of the root trace.
+    ///
+    /// This is useful for custom transaction types (e.g. account abstraction batches) where the
+    /// EVM's call entry point may not reflect the actual transaction sender.
+    #[inline]
+    pub fn set_transaction_caller(&mut self, caller: Address) {
+        if let Some(node) = self.traces.arena.first_mut() {
+            node.trace.caller = caller;
+        }
+    }
+
+    /// Manually set the target address of the root trace.
+    ///
+    /// This is useful for custom transaction types (e.g. account abstraction batches) where the
+    /// EVM's call entry point may not reflect the actual transaction target.
+    #[inline]
+    pub fn set_transaction_target(&mut self, target: Address) {
+        if let Some(node) = self.traces.arena.first_mut() {
+            node.trace.address = target;
+        }
+    }
+
     /// Consumes the Inspector and returns a [ParityTraceBuilder].
     #[inline]
     pub fn into_parity_builder(self) -> ParityTraceBuilder {


### PR DESCRIPTION
Adds `set_transaction_caller` and `set_transaction_target` to `TracingInspector`, following the same pattern as `set_transaction_gas_used` / `set_transaction_gas_limit`.

Custom transaction types (e.g. AA batches) may execute via a multi-call handler where the EVM's `call()` entry point doesn't reflect the actual transaction sender/recipient. This causes `callTracer` to report zeroed `from`/`to` on the root frame. These methods allow the execution layer to correct the root trace after execution.

Co-Authored-By: zhygis <5236121+Zygimantass@users.noreply.github.com>

Prompted by: zygis