### PR TITLE
chore: bump alloy to 2.0.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth
-alloy-rpc-types-eth = { version = "2.0.0-rc.0", default-features = false }
-alloy-rpc-types-trace = { version = "2.0.0-rc.0", default-features = false }
+alloy-rpc-types-eth = { version = "2.0.0-rc.1", default-features = false }
+alloy-rpc-types-trace = { version = "2.0.0-rc.1", default-features = false }
 alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
@@ -68,13 +68,13 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "100a3325ac4d624f3eb0bd404125750e76edf8ca" }
+alloy-rpc-types-eth = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-serde = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-network = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-network-primitives = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "4b68a95f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "34.0.0", default-features = false }
+revm = { version = "36.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
Bump alloy dependency versions from `2.0.0-rc.0` to `2.0.0-rc.1` and update all `[patch.crates-io]` revs to alloy `release/2.0.0-rc.1` HEAD (`4b68a95f`).