### PR TITLE
chore: bump alloy to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,8 @@ clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth
-alloy-rpc-types-eth = { version = "1.0.38", default-features = false }
-alloy-rpc-types-trace = { version = "1.0.38", default-features = false }
+alloy-rpc-types-eth = { version = "2.0", default-features = false }
+alloy-rpc-types-trace = { version = "2.0", default-features = false }
 alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -4,8 +4,8 @@ use alloy_primitives::{map::HashMap, Address, Log, U256};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     mux::{MuxConfig, MuxFrame},
-    CallConfig, FlatCallConfig, FourByteFrame, GethDebugBuiltInTracerType, NoopFrame,
-    PreStateConfig,
+    CallConfig, FlatCallConfig, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
+    NoopFrame, PreStateConfig,
 };
 use revm::{
     context_interface::{
@@ -47,53 +47,56 @@ impl MuxInspector {
 
         // Process each tracer configuration
         for (tracer_type, tracer_config) in config.0 {
+            let builtin = match tracer_type {
+                GethDebugTracerType::BuiltInTracer(b) => b,
+                _ => return Err(Error::UnsupportedTracerType(tracer_type)),
+            };
             #[allow(unreachable_patterns)]
-            match tracer_type {
+            match builtin {
                 GethDebugBuiltInTracerType::FourByteTracer => {
                     if tracer_config.is_some() {
-                        return Err(Error::UnexpectedConfig(tracer_type));
+                        return Err(Error::UnexpectedConfig(builtin));
                     }
                     four_byte = Some(FourByteInspector::default());
                 }
                 GethDebugBuiltInTracerType::CallTracer => {
-                    let call_config = tracer_config
-                        .ok_or(Error::MissingConfig(tracer_type))?
-                        .into_call_config()?;
+                    let call_config =
+                        tracer_config.ok_or(Error::MissingConfig(builtin))?.into_call_config()?;
 
                     inspector_config
                         .merge(TracingInspectorConfig::from_geth_call_config(&call_config));
-                    configs.push((tracer_type, TraceConfig::Call(call_config)));
+                    configs.push((builtin, TraceConfig::Call(call_config)));
                 }
                 GethDebugBuiltInTracerType::PreStateTracer => {
                     let prestate_config = tracer_config
-                        .ok_or(Error::MissingConfig(tracer_type))?
+                        .ok_or(Error::MissingConfig(builtin))?
                         .into_pre_state_config()?;
 
                     inspector_config
                         .merge(TracingInspectorConfig::from_geth_prestate_config(&prestate_config));
-                    configs.push((tracer_type, TraceConfig::PreState(prestate_config)));
+                    configs.push((builtin, TraceConfig::PreState(prestate_config)));
                 }
                 GethDebugBuiltInTracerType::NoopTracer => {
                     if tracer_config.is_some() {
-                        return Err(Error::UnexpectedConfig(tracer_type));
+                        return Err(Error::UnexpectedConfig(builtin));
                     }
-                    configs.push((tracer_type, TraceConfig::Noop));
+                    configs.push((builtin, TraceConfig::Noop));
                 }
                 GethDebugBuiltInTracerType::FlatCallTracer => {
                     let flatcall_config = tracer_config
-                        .ok_or(Error::MissingConfig(tracer_type))?
+                        .ok_or(Error::MissingConfig(builtin))?
                         .into_flat_call_config()?;
 
                     inspector_config
                         .merge(TracingInspectorConfig::from_flat_call_config(&flatcall_config));
-                    configs.push((tracer_type, TraceConfig::FlatCall(flatcall_config)));
+                    configs.push((builtin, TraceConfig::FlatCall(flatcall_config)));
                 }
                 GethDebugBuiltInTracerType::MuxTracer => {
-                    return Err(Error::UnexpectedConfig(tracer_type));
+                    return Err(Error::UnexpectedConfig(builtin));
                 }
                 _ => {
                     // keep this so that new variants can be supported
-                    return Err(Error::UnexpectedConfig(tracer_type));
+                    return Err(Error::UnexpectedConfig(builtin));
                 }
             }
         }
@@ -148,13 +151,13 @@ impl MuxInspector {
                 TraceConfig::Noop => NoopFrame::default().into(),
             };
 
-            frame.insert(*tracer_type, trace);
+            frame.insert(GethDebugTracerType::BuiltInTracer(*tracer_type), trace);
         }
 
         // Add four byte trace if inspector exists
         if let Some(inspector) = &self.four_byte {
             frame.insert(
-                GethDebugBuiltInTracerType::FourByteTracer,
+                GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FourByteTracer),
                 FourByteFrame::from(inspector).into(),
             );
         }
@@ -284,6 +287,9 @@ pub enum Error {
     /// Expected config is missing
     #[error("expected config is missing for tracer '{0:?}'")]
     MissingConfig(GethDebugBuiltInTracerType),
+    /// Unsupported tracer type (e.g. JS tracer)
+    #[error("unsupported tracer type: '{0:?}'")]
+    UnsupportedTracerType(GethDebugTracerType),
     /// Error when deserializing the config
     #[error("error deserializing config: {0}")]
     InvalidConfig(#[from] serde_json::Error),

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -4,7 +4,8 @@ use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256}
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     erc7562::Erc7562Config, mux::MuxConfig, CallConfig, FlatCallConfig, GethDebugBuiltInTracerType,
-    GethDebugTracerConfig, GethDebugTracingOptions, GethTrace, PreStateConfig, PreStateFrame,
+    GethDebugTracerConfig, GethDebugTracerType, GethDebugTracingOptions, GethTrace, PreStateConfig,
+    PreStateFrame,
 };
 use revm::{
     bytecode::{opcode, Bytecode},
@@ -206,17 +207,17 @@ fn test_geth_mux_tracer() {
     let prestate_config = PreStateConfig { diff_mode: Some(false), ..Default::default() };
 
     let config = MuxConfig(HashMap::from_iter([
-        (GethDebugBuiltInTracerType::FourByteTracer, None),
+        (GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FourByteTracer), None),
         (
-            GethDebugBuiltInTracerType::CallTracer,
+            GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer),
             Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
         ),
         (
-            GethDebugBuiltInTracerType::PreStateTracer,
+            GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::PreStateTracer),
             Some(GethDebugTracerConfig(serde_json::to_value(prestate_config).unwrap())),
         ),
         (
-            GethDebugBuiltInTracerType::FlatCallTracer,
+            GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FlatCallTracer),
             Some(GethDebugTracerConfig(serde_json::to_value(flatcall_config).unwrap())),
         ),
     ]));
@@ -242,12 +243,22 @@ fn test_geth_mux_tracer() {
         inspector.try_into_mux_frame(&res, ctx.db_ref(), TransactionInfo::default()).unwrap();
 
     assert_eq!(frame.0.len(), 4);
-    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::FourByteTracer));
-    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::CallTracer));
-    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::PreStateTracer));
-    assert!(frame.0.contains_key(&GethDebugBuiltInTracerType::FlatCallTracer));
+    assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
+        GethDebugBuiltInTracerType::FourByteTracer
+    )));
+    assert!(frame
+        .0
+        .contains_key(&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer)));
+    assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
+        GethDebugBuiltInTracerType::PreStateTracer
+    )));
+    assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
+        GethDebugBuiltInTracerType::FlatCallTracer
+    )));
 
-    let four_byte_frame = frame.0[&GethDebugBuiltInTracerType::FourByteTracer].clone();
+    let four_byte_frame = frame.0
+        [&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FourByteTracer)]
+        .clone();
     match four_byte_frame {
         GethTrace::FourByteTracer(four_byte_frame) => {
             assert_eq!(four_byte_frame.0.len(), 4);
@@ -259,7 +270,9 @@ fn test_geth_mux_tracer() {
         _ => panic!("Expected FourByteTracer"),
     }
 
-    let call_frame = frame.0[&GethDebugBuiltInTracerType::CallTracer].clone();
+    let call_frame = frame.0
+        [&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer)]
+        .clone();
     match call_frame {
         GethTrace::CallTracer(call_frame) => {
             assert_eq!(call_frame.calls.len(), 3);
@@ -268,7 +281,9 @@ fn test_geth_mux_tracer() {
         _ => panic!("Expected CallTracer"),
     }
 
-    let prestate_frame = frame.0[&GethDebugBuiltInTracerType::PreStateTracer].clone();
+    let prestate_frame = frame.0
+        [&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::PreStateTracer)]
+        .clone();
     match prestate_frame {
         GethTrace::PreStateTracer(prestate_frame) => {
             if let PreStateFrame::Default(prestate_mode) = prestate_frame {
@@ -280,7 +295,9 @@ fn test_geth_mux_tracer() {
         _ => panic!("Expected PreStateTracer"),
     }
 
-    let flatcall_frame = frame.0[&GethDebugBuiltInTracerType::FlatCallTracer].clone();
+    let flatcall_frame = frame.0
+        [&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FlatCallTracer)]
+        .clone();
     match flatcall_frame {
         GethTrace::FlatCallTracer(traces) => {
             assert_eq!(traces.len(), 6);


### PR DESCRIPTION
Bump alloy dependencies to 2.0.0 (released). No `[patch.crates-io]` needed.

Supersedes #419