### PR TITLE
fix: check if opcode is valid

### DIFF
--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -540,9 +540,7 @@ impl TracingInspector {
         if self.config.record_stack_snapshots.is_all()
             || self.config.record_stack_snapshots.is_pushes()
         {
-            // this can potentially underflow if the stack is malformed.
-            // outputs() calls info() which panics on unknown opcodes created via
-            // new_unchecked, so guard with is_valid().
+            // Check if op is valid and return zero
             let outputs = if step.op.is_valid() { step.op.outputs() as usize } else { 0 };
             let start = interp.stack.len().saturating_sub(outputs);
             step.push_stack = Some(interp.stack.data()[start..].into());

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -541,9 +541,14 @@ impl TracingInspector {
             || self.config.record_stack_snapshots.is_pushes()
         {
             let outputs = if step.op.is_valid() { step.op.outputs() as usize } else { 0 };
-            let start = interp.stack.len().saturating_sub(outputs);
-            step.push_stack =
-                Some(interp.stack.data().get(start..).unwrap_or_default().into());
+            step.push_stack = Some(
+                interp
+                    .stack
+                    .data()
+                    .get(interp.stack.len().saturating_sub(outputs)..)
+                    .unwrap_or_default()
+                    .into(),
+            );
         }
 
         let journal = context.journal_ref().journal();

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -540,10 +540,10 @@ impl TracingInspector {
         if self.config.record_stack_snapshots.is_all()
             || self.config.record_stack_snapshots.is_pushes()
         {
-            // Check if op is valid and return zero
             let outputs = if step.op.is_valid() { step.op.outputs() as usize } else { 0 };
             let start = interp.stack.len().saturating_sub(outputs);
-            step.push_stack = Some(interp.stack.data()[start..].into());
+            step.push_stack =
+                Some(interp.stack.data().get(start..).unwrap_or_default().into());
         }
 
         let journal = context.journal_ref().journal();

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -540,8 +540,11 @@ impl TracingInspector {
         if self.config.record_stack_snapshots.is_all()
             || self.config.record_stack_snapshots.is_pushes()
         {
-            // this can potentially underflow if the stack is malformed
-            let start = interp.stack.len().saturating_sub(step.op.outputs() as usize);
+            // this can potentially underflow if the stack is malformed.
+            // outputs() calls info() which panics on unknown opcodes created via
+            // new_unchecked, so guard with is_valid().
+            let outputs = if step.op.is_valid() { step.op.outputs() as usize } else { 0 };
+            let start = interp.stack.len().saturating_sub(outputs);
             step.push_stack = Some(interp.stack.data()[start..].into());
         }
 

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -710,7 +710,7 @@ impl CallTraceStep {
             error: self.as_error(),
             gas: self.gas_remaining,
             gas_cost: self.gas_cost,
-            op: self.op.as_str().into(),
+            op: self.op.to_string().into(),
             pc: self.pc as u64,
             refund_counter: (self.gas_refund_counter > 0).then_some(self.gas_refund_counter),
             stack: if opts.is_stack_enabled() {

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -710,7 +710,7 @@ impl CallTraceStep {
             error: self.as_error(),
             gas: self.gas_remaining,
             gas_cost: self.gas_cost,
-            op: self.op.to_string().into(),
+            op: if self.op.is_valid() { self.op.as_str().into() } else { "Unknown".into() },
             pc: self.pc as u64,
             refund_counter: (self.gas_refund_counter > 0).then_some(self.gas_refund_counter),
             stack: if opts.is_stack_enabled() {


### PR DESCRIPTION
TracingInspector creates OpCodes via `new_unchecked` at `start_step` to handle unknown/custom opcodes. In `step_end`, `step.op.outputs()` calls `OpCode::info()` which panics with `"opcode not found"` when the opcode byte has no entry in `OPCODE_INFO`.

Guard with `is_valid()` — unknown opcodes default to 0 outputs.

Prompted by: Dragan