### PR TITLE
fix(tracing): always include refund counter, wire enableReturnData config

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -195,6 +195,7 @@ impl TracingInspectorConfig {
                 StackSnapshotType::Full
             },
             record_state_diff: !config.disable_storage.unwrap_or_default(),
+            record_returndata_snapshots: config.is_return_data_enabled(),
             ..Self::default_geth()
         }
     }

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -712,7 +712,7 @@ impl CallTraceStep {
             gas_cost: self.gas_cost,
             op: self.op.as_str().into(),
             pc: self.pc as u64,
-            refund_counter: (self.gas_refund_counter > 0).then_some(self.gas_refund_counter),
+            refund_counter: Some(self.gas_refund_counter),
             stack: if opts.is_stack_enabled() {
                 self.stack.as_ref().map(|stack| stack.to_vec())
             } else {


### PR DESCRIPTION
Two fixes based on the [ethpandaops trace comparison](https://investigations.ethpandaops.io/2026-01/trace-comparisons/):

1. Always include the refund counter in struct logs, even when zero. Previously omitted when value was 0, causing missing fields in trace output.

2. Wire `enableReturnData` from `GethDefaultTracingOptions` through to `TracingInspectorConfig::record_returndata_snapshots`. Previously this option was ignored, so returnData was never captured even when explicitly requested.

Verified on a live reth archive node:
- Refund: 22,476/67,028 steps → **67,028/67,028** steps
- returnData with `enableReturnData: true`: 0 steps → **24,537** steps