### PR TITLE
fix(tracing): align memory encoding and returnData gating

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -96,7 +96,7 @@ impl<'a> GethTraceBuilder<'a> {
                 }
             }
 
-            if opts.is_return_data_enabled() && !step.returndata.is_empty() {
+            if opts.is_return_data_enabled() {
                 log.return_data = Some(step.returndata.clone());
             }
 

--- a/src/tracing/utils.rs
+++ b/src/tracing/utils.rs
@@ -79,12 +79,12 @@ pub(crate) fn convert_memory(data: &[u8]) -> Vec<String> {
     let chunks = data.chunks_exact(32);
     let remainder = chunks.remainder();
     for chunk in chunks {
-        memory.push(hex::encode(chunk));
+        memory.push(format!("0x{}", hex::encode(chunk)));
     }
     if !remainder.is_empty() {
         let mut last_chunk = [0u8; 32];
         last_chunk[..remainder.len()].copy_from_slice(remainder);
-        memory.push(hex::encode(last_chunk));
+        memory.push(format!("0x{}", hex::encode(last_chunk)));
     }
     memory
 }

--- a/src/tracing/utils.rs
+++ b/src/tracing/utils.rs
@@ -79,12 +79,12 @@ pub(crate) fn convert_memory(data: &[u8]) -> Vec<String> {
     let chunks = data.chunks_exact(32);
     let remainder = chunks.remainder();
     for chunk in chunks {
-        memory.push(format!("0x{}", hex::encode(chunk)));
+        memory.push(hex::encode_prefixed(chunk));
     }
     if !remainder.is_empty() {
         let mut last_chunk = [0u8; 32];
         last_chunk[..remainder.len()].copy_from_slice(remainder);
-        memory.push(format!("0x{}", hex::encode(last_chunk)));
+        memory.push(hex::encode_prefixed(last_chunk));
     }
     memory
 }
@@ -214,5 +214,18 @@ mod tests {
         let err = hex!("0x08c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000214661696c656420746f2076657269667920424950333232207369676e617475726500000000000000000000000000000000000000000000000000000000000000");
         let reason = maybe_revert_reason(&err[..]).unwrap();
         assert_eq!(reason, "Failed to verify BIP322 signature".to_string());
+    }
+
+    #[test]
+    fn convert_memory_prefixes_and_zero_pads_chunks() {
+        let data = (0u8..33).collect::<Vec<_>>();
+
+        assert_eq!(
+            convert_memory(&data),
+            vec![
+                "0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f".to_string(),
+                "0x2000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            ]
+        );
     }
 }

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -4,8 +4,8 @@ use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256}
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     erc7562::Erc7562Config, mux::MuxConfig, CallConfig, FlatCallConfig, GethDebugBuiltInTracerType,
-    GethDebugTracerConfig, GethDebugTracerType, GethDebugTracingOptions, GethTrace, PreStateConfig,
-    PreStateFrame,
+    GethDebugTracerConfig, GethDebugTracerType, GethDebugTracingOptions, GethDefaultTracingOptions,
+    GethTrace, PreStateConfig, PreStateFrame,
 };
 use revm::{
     bytecode::{opcode, Bytecode},
@@ -777,6 +777,67 @@ fn test_geth_prestate_diff_selfdestruct_london() {
 #[test]
 fn test_geth_prestate_diff_selfdestruct_cancun() {
     test_geth_prestate_diff_selfdestruct(SpecId::CANCUN);
+}
+
+#[test]
+fn test_geth_default_tracer_empty_return_data_is_serialized_when_enabled() {
+    let contract = address!("0xc000000000000000000000000000000000000003");
+    let caller = address!("0xa000000000000000000000000000000000000003");
+    let code = hex!("00");
+
+    let context = Context::mainnet()
+        .with_db(CacheDB::<EmptyDB>::default())
+        .modify_cfg_chained(|cfg| cfg.spec = SpecId::LONDON)
+        .modify_db_chained(|db| {
+            db.insert_account_info(
+                contract,
+                AccountInfo { code: Some(Bytecode::new_raw(code.into())), ..Default::default() },
+            );
+            db.insert_account_info(
+                caller,
+                AccountInfo {
+                    balance: revm::primitives::U256::from(1_000_000_000),
+                    ..Default::default()
+                },
+            );
+        });
+
+    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
+    let mut evm = context.build_mainnet().with_inspector(&mut insp);
+
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 1_000_000,
+            gas_price: 0,
+            kind: TransactTo::Call(contract),
+            data: Bytes::default(),
+            nonce: 0,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "Transaction should succeed: {res:#?}");
+
+    let frame =
+        insp.with_transaction_gas_used(res.result.tx_gas_used()).geth_builder().geth_traces(
+            res.result.tx_gas_used(),
+            res.result.output().unwrap_or_default().clone(),
+            GethDefaultTracingOptions::default().enable_return_data(),
+        );
+
+    assert!(!frame.struct_logs.is_empty(), "Expected struct logs for STOP execution");
+    assert!(frame.struct_logs.iter().all(|log| log.return_data == Some(Bytes::default())));
+
+    let struct_logs = serde_json::to_value(&frame)
+        .unwrap()
+        .get("structLogs")
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap();
+
+    assert!(struct_logs.iter().all(|log| {
+        log.get("returnData") == Some(&serde_json::Value::String("0x".to_string()))
+    }));
 }
 
 fn test_geth_prestate_diff_selfdestruct(spec_id: SpecId) {


### PR DESCRIPTION
Two fixes to align with the [opcode tracer spec](https://github.com/ethereum/execution-apis/pull/762):

1. Memory chunks now use `0x`-prefixed `bytes32` encoding. Previously `convert_memory()` used bare `hex::encode` without the prefix.

2. `returnData` is now included on every step when `enableReturnData` is true, even when the buffer is empty. Previously skipped when empty.