### PR TITLE
chore: bump revm to 38.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "37.0.0", default-features = false }
+revm = { version = "38.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
## Summary
- Bumps `revm` from `37.0.0` to `38.0.0`.

## Test plan
- [ ] `cargo build` passes
- [ ] `cargo test` passes
- [ ] CI green