### PR TITLE
devnet4: integrate revm devnet4 (rev 7a2de5a4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "38.0.0", default-features = false }
+revm = { version = "37.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"
@@ -66,4 +66,18 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -425,7 +425,7 @@ impl TracingInspector {
     ) {
         // We always want an OpCode, even it is unknown because it could be an additional opcode
         // that not a known constant.
-        let op = unsafe { OpCode::new_unchecked(interp.bytecode.opcode()) };
+        let op = OpCode::new_or_unknown(interp.bytecode.opcode());
 
         let record = self.config.should_record_opcode(op);
         self.record_step_end = record;


### PR DESCRIPTION
Patch revm to devnet4 commit \`7a2de5a4\`. Brings in:

- EIP-8037 dynamic CPSB derived from block gas limit
- EIP-7981 access list cost increase
- EIP-7976 calldata floor cost bump (64/64)
- EIP-8037 issue #2 — 0→x→0 storage reservoir refill

Workspace \`revm\` requirement downgraded from 38.0.0 to 37.0.0 to match the patched git source (devnet4 is based on v106).