### PR TITLE
feat(bal-devnet-4): integrate revm (rev 3ed3bdfe)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "37.0.0", default-features = false }
+revm = { version = "38.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"
@@ -68,16 +68,16 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "fe2549d85fb9e201e7b629f8b47bcca46d49aa1d" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "38.0.0", default-features = false }
+revm = { version = "37.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"
@@ -66,4 +66,18 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "7a2de5a4afe155f563120a02bfd96e64fa1bb158" }
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -425,7 +425,7 @@ impl TracingInspector {
     ) {
         // We always want an OpCode, even it is unknown because it could be an additional opcode
         // that not a known constant.
-        let op = unsafe { OpCode::new_unchecked(interp.bytecode.opcode()) };
+        let op = OpCode::new_or_unknown(interp.bytecode.opcode());
 
         let record = self.config.should_record_opcode(op);
         self.record_step_end = record;


### PR DESCRIPTION
## Summary
- Bump revm to commit `3ed3bdfed9ad6e5ba37f4e1f015436ab89ca98be`
- Bump `revm` dep version from 37.0.0 → 38.0.0 to match the new patched crate version

## Test plan
- [x] `cargo build --all-features` succeeds