### PR TITLE
fix(test): use .values() to satisfy nightly clippy for_kv_map lint

### DIFF
--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -623,7 +623,7 @@ fn test_geth_prestate_disable_code_in_diff_mode() {
     match frame {
         PreStateFrame::Diff(diff_mode) => {
             // Check that no account in pre state has code
-            for (_, account_state) in diff_mode.pre.iter() {
+            for account_state in diff_mode.pre.values() {
                 assert!(
                     account_state.code.is_none(),
                     "Code should be None in pre state when disable_code=true"
@@ -631,7 +631,7 @@ fn test_geth_prestate_disable_code_in_diff_mode() {
             }
 
             // Check that no account in post state has code
-            for (_, account_state) in diff_mode.post.iter() {
+            for account_state in diff_mode.post.values() {
                 assert!(
                     account_state.code.is_none(),
                     "Code should be None in post state when disable_code=true"


### PR DESCRIPTION
Nightly clippy (since [rust-lang/rust-clippy#16830](https://github.com/rust-lang/rust-clippy/pull/16830), merged 2026-04-20) now correctly detects `for (_, v) in map.iter()` as a `for_kv_map` violation. This was previously a false negative.

This breaks the clippy CI job on all PRs using nightly after 2026-04-21 (e.g. #433).

Fix: replace `.iter()` with `.values()` in the prestate diff test.