### PR TITLE
feat: Amsterdam bal-devnet-7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,16 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "9ccf9e5800e7308f0a591c0493ae8e0de35317f8" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,17 @@ std = [
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "191c163a23569a94097c4f9a7291158183fce256" }
+


### PR DESCRIPTION
## Integration Summary

Patches revm to the latest `bal-devnet-7` commit so revm-inspectors compiles against the Amsterdam BAL changes.

## Staged Crates

### revm
- **Commit**: `191c163a23569a94097c4f9a7291158183fce256`
- **Changes**:
  - fix(eip8037): unwind grandchild storage-clear refund on revert/halt
  - fix(eip8037): align top-level revert/halt reservoir refund with child-frame rule
  - fix(eip8037): plumb new-account state-gas refund, bump CPSB to 1530, fix clippy