### PR TITLE
fix: address clippy map iteration lint

### DIFF
--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -623,7 +623,7 @@ fn test_geth_prestate_disable_code_in_diff_mode() {
     match frame {
         PreStateFrame::Diff(diff_mode) => {
             // Check that no account in pre state has code
-            for (_, account_state) in diff_mode.pre.iter() {
+            for account_state in diff_mode.pre.values() {
                 assert!(
                     account_state.code.is_none(),
                     "Code should be None in pre state when disable_code=true"
@@ -631,7 +631,7 @@ fn test_geth_prestate_disable_code_in_diff_mode() {
             }
 
             // Check that no account in post state has code
-            for (_, account_state) in diff_mode.post.iter() {
+            for account_state in diff_mode.post.values() {
                 assert!(
                     account_state.code.is_none(),
                     "Code should be None in post state when disable_code=true"


### PR DESCRIPTION
## What changed

Updated the geth prestate diff-mode test to iterate over account state values directly instead of destructuring ignored map keys.

## Why

The latest clippy flags the ignored-key map iteration pattern with `clippy::for_kv_map`. CI runs clippy with warnings denied, so this warning fails the clippy job.

## Impact

No behavior change. This only adjusts the test iteration style to match clippy's preferred map API.