### PR TITLE
refactor: relax `JsInspector` bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,5 @@ std = [
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "c154af02" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,3 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
-
-[patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "c154af02" }

--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -302,7 +302,7 @@ macro_rules! delegate {
 
 impl<CTX> Inspector<CTX> for DebugInspector
 where
-    CTX: ContextTr<Journal: JournalExt, Db: DatabaseRef>,
+    CTX: ContextTr<Journal: JournalExt>,
 {
     fn initialize_interp(&mut self, interp: &mut Interpreter, context: &mut CTX) {
         delegate!(self => inspector.initialize_interp(interp, context))

--- a/src/tracing/js/bindings.rs
+++ b/src/tracing/js/bindings.rs
@@ -30,7 +30,7 @@ use revm::{
     interpreter::{SharedMemory, Stack},
     primitives::KECCAK_EMPTY,
     state::{AccountInfo, Bytecode, EvmState},
-    DatabaseRef,
+    Database, DatabaseRef,
 };
 
 /// A macro that creates a native function that returns via [JsValue::from]
@@ -830,9 +830,9 @@ pub(crate) struct EvmDbRef {
 
 impl EvmDbRef {
     /// Creates a new evm and db JS object.
-    pub(crate) fn new<'a, 'b, DB>(state: &'a EvmState, db: &'b DB) -> (Self, EvmDbGuard<'a, 'b>)
+    pub(crate) fn new<'a, 'b, DB>(state: &'a EvmState, db: &'b mut DB) -> (Self, EvmDbGuard<'a, 'b>)
     where
-        DB: DatabaseRef,
+        DB: Database,
         DB::Error: core::fmt::Display,
     {
         let (state, state_guard) = StateRef::new(state);
@@ -843,7 +843,7 @@ impl EvmDbRef {
         // As mentioned in the `Safety` section of [GuardedNullableGc] the caller of this function
         // needs to guarantee that the passed-in lifetime is sufficiently long for the lifetime of
         // the guard.
-        let db = JsDb(db);
+        let db = JsDb(RefCell::new(db));
         let js_db = unsafe {
             core::mem::transmute::<
                 Box<dyn DatabaseRef<Error = StringError> + '_>,
@@ -1028,7 +1028,10 @@ pub(crate) struct EvmDbGuard<'a, 'b> {
 }
 
 /// A wrapper Database for the JS context.
-pub(crate) struct JsDb<DB: DatabaseRef>(DB);
+///
+/// Wraps a `&mut DB: Database` in a `RefCell` so that the `&self` methods of
+/// [`DatabaseRef`] can drive the underlying `Database` (which requires `&mut self`).
+pub(crate) struct JsDb<'a, DB>(RefCell<&'a mut DB>);
 
 #[derive(Clone, Debug)]
 pub(crate) struct StringError(pub String);
@@ -1048,27 +1051,27 @@ impl From<String> for StringError {
     }
 }
 
-impl<DB> DatabaseRef for JsDb<DB>
+impl<DB> DatabaseRef for JsDb<'_, DB>
 where
-    DB: DatabaseRef,
+    DB: Database,
     DB::Error: core::fmt::Display,
 {
     type Error = StringError;
 
-    fn basic_ref(&self, _address: Address) -> Result<Option<AccountInfo>, Self::Error> {
-        self.0.basic_ref(_address).map_err(|e| e.to_string().into())
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.0.borrow_mut().basic(address).map_err(|e| e.to_string().into())
     }
 
-    fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
-        self.0.code_by_hash_ref(_code_hash).map_err(|e| e.to_string().into())
+    fn code_by_hash_ref(&self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.0.borrow_mut().code_by_hash(code_hash).map_err(|e| e.to_string().into())
     }
 
-    fn storage_ref(&self, _address: Address, _index: U256) -> Result<U256, Self::Error> {
-        self.0.storage_ref(_address, _index).map_err(|e| e.to_string().into())
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.0.borrow_mut().storage(address, index).map_err(|e| e.to_string().into())
     }
 
-    fn block_hash_ref(&self, _number: u64) -> Result<B256, Self::Error> {
-        self.0.block_hash_ref(_number).map_err(|e| e.to_string().into())
+    fn block_hash_ref(&self, number: u64) -> Result<B256, Self::Error> {
+        self.0.borrow_mut().block_hash(number).map_err(|e| e.to_string().into())
     }
 }
 
@@ -1166,7 +1169,7 @@ mod tests {
         let mut db = CacheDB::new(EmptyDB::new());
         let state = EvmState::default();
         {
-            let (db, guard) = EvmDbRef::new(&state, &db);
+            let (db, guard) = EvmDbRef::new(&state, &mut db);
             let addr = Address::default();
             let addr = JsValue::from(js_string!(addr.to_string()));
             let db = db.into_js_object(&mut context).unwrap();
@@ -1182,7 +1185,7 @@ mod tests {
         db.insert_account_info(addr, Default::default());
 
         {
-            let (db, guard) = EvmDbRef::new(&state, &db);
+            let (db, guard) = EvmDbRef::new(&state, &mut db);
             let addr = JsValue::from(js_string!(addr.to_string()));
             let db = db.into_js_object(&mut context).unwrap();
             let res = f.call(&result, &[db.clone().into(), addr.clone()], &mut context).unwrap();
@@ -1218,10 +1221,10 @@ mod tests {
         let result_fn = obj.get(js_string!("result"), &mut context).unwrap().as_object().unwrap();
         let setup_fn = obj.get(js_string!("setup"), &mut context).unwrap().as_object().unwrap();
 
-        let db = CacheDB::new(EmptyDB::new());
+        let mut db = CacheDB::new(EmptyDB::new());
         let state = EvmState::default();
         {
-            let (db_ref, guard) = EvmDbRef::new(&state, &db);
+            let (db_ref, guard) = EvmDbRef::new(&state, &mut db);
             let js_db = db_ref.into_js_object(&mut context).unwrap();
             let _res = setup_fn.call(&(obj.clone().into()), &[js_db.into()], &mut context).unwrap();
             assert!(obj.get(js_string!("db"), &mut context).unwrap().is_object());

--- a/src/tracing/js/mod.rs
+++ b/src/tracing/js/mod.rs
@@ -28,6 +28,7 @@ use revm::{
         result::{ExecutionResult, HaltReasonTr, Output, ResultAndState},
         Block, ContextTr, TransactTo, Transaction,
     },
+    database::WrapDatabaseRef,
     inspector::JournalExt,
     interpreter::{
         interpreter_types::{Jumps, LoopControl},
@@ -286,7 +287,8 @@ impl JsInspector {
         <DB as DatabaseRef>::Error: core::fmt::Display,
     {
         let ResultAndState { result, state } = res;
-        let (db, _db_guard) = EvmDbRef::new(&state, db);
+        let mut db = WrapDatabaseRef(db);
+        let (db, _db_guard) = EvmDbRef::new(&state, &mut db);
 
         let gas_used = result.tx_gas_used();
         let mut to = None;
@@ -446,7 +448,7 @@ impl JsInspector {
 
 impl<CTX> Inspector<CTX> for JsInspector
 where
-    CTX: ContextTr<Journal: JournalExt, Db: DatabaseRef>,
+    CTX: ContextTr<Journal: JournalExt>,
 {
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
         if self.step_fn.is_none() {
@@ -499,7 +501,8 @@ where
         // Compute the actual gas cost now that the opcode has executed
         let cost = interp.gas.total_gas_spent().saturating_sub(pending.gas_spent_before);
 
-        let (db, _db_guard) = EvmDbRef::new(context.journal_ref().evm_state(), context.db_ref());
+        let (db_mut, state) = context.journal_mut().db_and_state_mut();
+        let (db, _db_guard) = EvmDbRef::new(state, db_mut);
 
         let (stack, _stack_guard) = StackRef::new_owned(pending.stack);
         let (memory, _memory_guard) = MemoryRef::new_owned(self.cached_memory.clone());
@@ -802,7 +805,9 @@ mod tests {
 
         assert_eq!(res.result.is_success(), success);
         let (ctx, inspector) = evm.ctx_inspector();
-        inspector.json_result(res, ctx.tx(), ctx.block(), ctx.db_ref()).unwrap()
+        let tx = ctx.tx().clone();
+        let block = ctx.block().clone();
+        inspector.json_result(res, &tx, &block, ctx.db_mut()).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
Relaxes `JsInspector` so that it works with any database without requiring `DatabaseRef`