### PR TITLE
fix: record all stack snapshots in TracingInspectorConfig::all()

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -84,7 +84,7 @@ impl TracingInspectorConfig {
         Self {
             record_steps: true,
             record_memory_snapshots: true,
-            record_stack_snapshots: StackSnapshotType::Full,
+            record_stack_snapshots: StackSnapshotType::All,
             record_state_diff: true,
             record_returndata_snapshots: true,
             record_opcodes_filter: None,
@@ -472,5 +472,14 @@ mod tests {
         let config = FlatCallConfig { include_precompiles: Some(false), ..Default::default() };
         let config = TracingInspectorConfig::from_flat_call_config(&config);
         assert!(config.exclude_precompile_calls);
+    }
+
+    #[test]
+    fn test_all_records_all_stack_snapshots() {
+        // `all()` enables everything, so the stack snapshot type should be the most
+        // complete variant (`All` = full stack + pushes), not `Full` (full only).
+        let config = TracingInspectorConfig::all();
+        assert_eq!(config.record_stack_snapshots, StackSnapshotType::All);
+        assert!(config.record_stack_snapshots.is_all());
     }
 }


### PR DESCRIPTION
## Motivation

Closes #343.

`TracingInspectorConfig::all()` is documented as "a config with everything
enabled", but it set `record_stack_snapshots` to `StackSnapshotType::Full`
instead of `StackSnapshotType::All`, the most complete variant.

This is not cosmetic. The two variants drive different code paths in the step
recorder:

* The full stack snapshot is taken for `Full` or `All` (`src/tracing/mod.rs`,
  in `start_step`).
* `step.push_stack` (the items an opcode pushes) is only recorded for `Pushes`
  or `All` (`src/tracing/mod.rs`, in the step-end fill).

So with `Full`, `all()` silently left `push_stack` as `None` on every step,
even though the method name and docs promise everything.

## Solution

Use `StackSnapshotType::All` in `all()` so `push_stack` is populated, matching
the method name and its doc. Adds a regression test asserting
`all().record_stack_snapshots == StackSnapshotType::All`.
