### PR TITLE
fix(erc7562): enable state diffs to capture SLOAD in accessedSlots.reads

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -222,6 +222,8 @@ impl TracingInspectorConfig {
             .set_memory_snapshots(true)
             // need stack snapshots for keccak preimages
             .set_stack_snapshots(StackSnapshotType::Full)
+            // need state diffs to capture SLOAD values in accessedSlots.reads
+            .set_state_diffs(true)
             .steps()
     }
 


### PR DESCRIPTION
The [`erc7562Tracer`](https://github.com/paradigmxyz/revm-inspectors/blob/main/src/tracing/builder/geth.rs#L387) config starts from `Self::none()` which sets `record_state_diff: false`. This causes SLOAD operations to not populate `accessedSlots.reads` because the SLOAD handler in [`geth_erc7562_traces()`](https://github.com/paradigmxyz/revm-inspectors/blob/main/src/tracing/builder/geth.rs#L427) depends on `step.storage_change`, which is only set when `record_state_diff` is enabled.

## Problem

```rust
// geth_erc7562_traces() — SLOAD handler (builder/geth.rs:427)
opcode::SLOAD => {
    if let Some(stack) = &step.stack {
        if let Some(slot) = stack.get(stack.len().saturating_sub(1)) {
            if !already_read && !already_written {
                if let Some(change) = &step.storage_change {  // <-- always None
                    accessed_slots.reads.entry(slot).or_default().push(value);
                }
            }
        }
    }
}
```

`step.storage_change` is only populated in [`step_end()`](https://github.com/paradigmxyz/revm-inspectors/blob/main/src/tracing/mod.rs#L554) when `self.config.record_state_diff` is true:

```rust
// tracing/mod.rs:554
step.storage_change = if matches!(op, opcode::SLOAD | opcode::SSTORE) {
    // only reached when record_state_diff is true
```

But [`from_geth_erc7562_config()`](https://github.com/paradigmxyz/revm-inspectors/blob/main/src/tracing/config.rs#L217) never enables it:

```rust
pub fn from_geth_erc7562_config(config: &Erc7562Config) -> Self {
    Self::none()                         // record_state_diff: false
        .set_record_logs(...)
        .set_memory_snapshots(true)
        .set_stack_snapshots(StackSnapshotType::Full)
        .steps()                         // missing .set_state_diffs(true)
}
```

## Steps to reproduce

1. Start a reth node and deploy a contract that uses SLOAD (e.g. a counter with `get()` and `increment()`):

```solidity
contract Counter {
    uint256 public count;
    function increment() external { count += 1; }
}
```

2. Call `increment()` a few times so slot 0 has a non-zero value.

3. Trace an `increment()` call with the [`erc7562Tracer`](https://github.com/paradigmxyz/revm-inspectors/blob/main/src/tracing/debug.rs#L120-L136):

```bash
curl -X POST http://localhost:8545 -H "Content-Type: application/json" -d '{ 
  "jsonrpc": "2.0", "id": 1,
  "method": "debug_traceCall",
  "params": [{
    "to": "<counter_address>",
    "data": "0xd09de08a"
  }, "latest", {"tracer": "erc7562Tracer"}]
}'
```

4. Observe that `accessedSlots.reads` is empty even though `increment()` does `SLOAD` on slot 0 before `SSTORE`:

```json
{
  "accessedSlots": {
    "reads": {},
    "writes": {"0x00..00": 1}
  }
}
```

**Expected:** `reads` should contain `{"0x00..00": ["<current_value>"]}` because the EVM performs an SLOAD before the SSTORE in `count += 1`.

**Actual:** `reads` is always empty.

Note: geth's implementation of the [same tracer](https://github.com/ethereum/go-ethereum/blob/master/eth/tracers/native/erc7562.go) correctly populates `accessedSlots.reads`.

## Impact

ERC-4337 bundlers (e.g. [Rundler](https://github.com/alchemyplatform/rundler)) need `(slot, initial_value)` pairs from SLOAD to enforce [ERC-7562](https://eips.ethereum.org/EIPS/eip-7562) storage access rules ([STO-010], [STO-031], etc.). Without this fix, the native `erc7562Tracer` cannot replace custom JS tracers, which are 4-100x slower due to per-opcode JS interpretation.

## Fix

One line: `.set_state_diffs(true)` in `from_geth_erc7562_config()`.
