### PR TITLE
chore: bump revm to tip1060

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,17 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "d9ff851f6350f047238bcfdf5a31b0f76e41e2f9" }


### PR DESCRIPTION
Bumps revm to the `tip1060` branch commit `d9ff851f6350f047238bcfdf5a31b0f76e41e2f9` (revm v40.0.3) via `[patch.crates-io]`.

Part of the tip1060 integration chain (revm → revm-inspectors → alloy-evm → reth-core → reth → tempo).