### PR TITLE
fix: remove transfer inspector reverted logs

### DIFF
--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -24,7 +24,7 @@ pub const TRANSFER_EVENT_TOPIC: B256 =
 pub struct TransferInspector {
     internal_only: bool,
     transfers: Vec<TransferOperation>,
-    call_checkpoints: Vec<TransferCheckpoint>,
+    checkpoints: Vec<TransferCheckpoint>,
     /// If enabled, will insert ERC20-style transfer logs emitted by [TRANSFER_LOG_EMITTER] for
     /// each ETH transfer.
     ///
@@ -38,12 +38,7 @@ impl TransferInspector {
     /// If `internal_only` is set to `true`, only internal transfers are collected, in other words,
     /// the top level call is ignored.
     pub fn new(internal_only: bool) -> Self {
-        Self {
-            internal_only,
-            transfers: Vec::new(),
-            call_checkpoints: Vec::new(),
-            insert_logs: false,
-        }
+        Self { internal_only, transfers: Vec::new(), checkpoints: Vec::new(), insert_logs: false }
     }
 
     /// Creates a new transfer inspector that only collects internal transfers.
@@ -70,6 +65,32 @@ impl TransferInspector {
     /// Returns an iterator over the collected transfers.
     pub fn iter(&self) -> impl Iterator<Item = &TransferOperation> {
         self.transfers.iter()
+    }
+
+    /// Records frame-entry lengths so synthetic transfer logs can follow EVM revert semantics on
+    /// `call_end` and `create_end`.
+    fn checkpoint<CTX: ContextTr>(&mut self, context: &CTX) {
+        if self.insert_logs {
+            self.checkpoints.push(TransferCheckpoint {
+                transfers_len: self.transfers.len(),
+                logs_len: context.journal().logs().len(),
+            });
+        }
+    }
+
+    /// Restores the inspector and journal after a reverted or halted frame.
+    /// This prevents RPC-only transfer logs from leaking out of failed execution.
+    fn rollback_transfers<DB: Database, JOURNAL: JournalTr<Database = DB>>(
+        &mut self,
+        journaled_state: &mut JOURNAL,
+        checkpoint: TransferCheckpoint,
+    ) {
+        self.transfers.truncate(checkpoint.transfers_len);
+
+        let logs = journaled_state.take_logs();
+        for log in logs.into_iter().take(checkpoint.logs_len) {
+            journaled_state.log(log);
+        }
     }
 
     fn on_transfer<DB: Database, JOURNAL: JournalTr<Database = DB>>(
@@ -103,6 +124,8 @@ impl TransferInspector {
     }
 }
 
+/// Transfer/log lengths captured at frame entry.
+/// Used only when synthetic transfer logs may need frame-local rollback.
 #[derive(Debug, Default, Clone, Copy)]
 struct TransferCheckpoint {
     transfers_len: usize,
@@ -114,12 +137,7 @@ where
     CTX: ContextTr,
 {
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        if self.insert_logs {
-            self.call_checkpoints.push(TransferCheckpoint {
-                transfers_len: self.transfers.len(),
-                logs_len: context.journal().logs().len(),
-            });
-        }
+        self.checkpoint(context);
 
         if let Some(value) = inputs.transfer_value() {
             self.on_transfer(
@@ -139,7 +157,7 @@ where
             return;
         }
 
-        let Some(checkpoint) = self.call_checkpoints.pop() else {
+        let Some(checkpoint) = self.checkpoints.pop() else {
             return;
         };
 
@@ -147,12 +165,7 @@ where
             return;
         }
 
-        self.transfers.truncate(checkpoint.transfers_len);
-
-        let logs = context.journal_mut().take_logs();
-        for log in logs.into_iter().take(checkpoint.logs_len) {
-            context.journal_mut().log(log);
-        }
+        self.rollback_transfers(context.journal_mut(), checkpoint);
     }
 
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
@@ -165,9 +178,31 @@ where
             CreateScheme::Custom { .. } => return None,
         };
 
+        self.checkpoint(context);
         self.on_transfer(inputs.caller(), address, inputs.value(), kind, context.journal_mut());
 
         None
+    }
+
+    fn create_end(
+        &mut self,
+        context: &mut CTX,
+        _inputs: &CreateInputs,
+        outcome: &mut CreateOutcome,
+    ) {
+        if !self.insert_logs {
+            return;
+        }
+
+        let Some(checkpoint) = self.checkpoints.pop() else {
+            return;
+        };
+
+        if outcome.result.is_ok() {
+            return;
+        }
+
+        self.rollback_transfers(context.journal_mut(), checkpoint);
     }
 
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -214,13 +214,6 @@ where
     }
 }
 
-/// Transfer/log lengths captured before the first transfer in a frame.
-#[derive(Debug, Default, Clone, Copy)]
-struct TransferCheckpoint {
-    transfers_len: usize,
-    logs_len: usize,
-}
-
 /// A transfer operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransferOperation {
@@ -245,4 +238,11 @@ pub enum TransferKind {
     Create2,
     /// A SELFDESTRUCT operation
     SelfDestruct,
+}
+
+/// Transfer/log lengths captured before the first transfer in a frame.
+#[derive(Debug, Default, Clone, Copy)]
+struct TransferCheckpoint {
+    transfers_len: usize,
+    logs_len: usize,
 }

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -5,7 +5,7 @@ use revm::{
     context::JournalTr,
     context_interface::ContextTr,
     interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome, CreateScheme},
-    Database, Inspector,
+    Inspector,
 };
 
 /// Sender of ETH transfer log per `eth_simulateV1` spec.
@@ -24,7 +24,7 @@ pub const TRANSFER_EVENT_TOPIC: B256 =
 pub struct TransferInspector {
     internal_only: bool,
     transfers: Vec<TransferOperation>,
-    checkpoints: Vec<TransferCheckpoint>,
+    checkpoints: Vec<Option<TransferCheckpoint>>,
     /// If enabled, will insert ERC20-style transfer logs emitted by [TRANSFER_LOG_EMITTER] for
     /// each ETH transfer.
     ///
@@ -67,33 +67,52 @@ impl TransferInspector {
         self.transfers.iter()
     }
 
-    /// Records frame-entry lengths so synthetic transfer logs can follow EVM revert semantics on
-    /// `call_end` and `create_end`.
-    fn checkpoint<CTX: ContextTr>(&mut self, context: &CTX) {
+    fn begin_frame(&mut self) {
         if self.insert_logs {
-            self.checkpoints.push(TransferCheckpoint {
-                transfers_len: self.transfers.len(),
-                logs_len: context.journal().logs().len(),
-            });
+            self.checkpoints.push(None);
         }
     }
 
-    /// Restores the inspector and journal after a reverted or halted frame.
-    /// This prevents RPC-only transfer logs from leaking out of failed execution.
-    fn rollback_transfers<DB: Database, JOURNAL: JournalTr<Database = DB>>(
-        &mut self,
-        journaled_state: &mut JOURNAL,
-        checkpoint: TransferCheckpoint,
-    ) {
+    fn checkpoint_transfer<JOURNAL: JournalTr>(&mut self, journaled_state: &JOURNAL) {
+        if !self.insert_logs {
+            return;
+        }
+
+        let checkpoint = TransferCheckpoint {
+            transfers_len: self.transfers.len(),
+            logs_len: journaled_state.logs().len(),
+        };
+
+        for frame_checkpoint in self.checkpoints.iter_mut().rev() {
+            if frame_checkpoint.is_some() {
+                break;
+            }
+            *frame_checkpoint = Some(checkpoint);
+        }
+    }
+
+    fn commit_transfers(&mut self) {
+        if self.insert_logs {
+            self.checkpoints.pop();
+        }
+    }
+
+    fn rollback_transfers<JOURNAL: JournalTr>(&mut self, journaled_state: &mut JOURNAL) {
+        let Some(checkpoint) = self.checkpoints.pop().flatten() else {
+            return;
+        };
+
         self.transfers.truncate(checkpoint.transfers_len);
 
-        let logs = journaled_state.take_logs();
-        for log in logs.into_iter().take(checkpoint.logs_len) {
+        let mut logs = journaled_state.take_logs();
+        logs.truncate(checkpoint.logs_len);
+        // `JournalTr` does not expose mutable logs, so preserve the prefix through its public API.
+        for log in logs {
             journaled_state.log(log);
         }
     }
 
-    fn on_transfer<DB: Database, JOURNAL: JournalTr<Database = DB>>(
+    fn on_transfer<JOURNAL: JournalTr>(
         &mut self,
         from: Address,
         to: Address,
@@ -109,6 +128,7 @@ impl TransferInspector {
         if value.is_zero() {
             return;
         }
+        self.checkpoint_transfer(journaled_state);
         self.transfers.push(TransferOperation { kind, from, to, value });
 
         if self.insert_logs {
@@ -124,20 +144,12 @@ impl TransferInspector {
     }
 }
 
-/// Transfer/log lengths captured at frame entry.
-/// Used only when synthetic transfer logs may need frame-local rollback.
-#[derive(Debug, Default, Clone, Copy)]
-struct TransferCheckpoint {
-    transfers_len: usize,
-    logs_len: usize,
-}
-
 impl<CTX> Inspector<CTX> for TransferInspector
 where
     CTX: ContextTr,
 {
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        self.checkpoint(context);
+        self.begin_frame();
 
         if let Some(value) = inputs.transfer_value() {
             self.on_transfer(
@@ -153,22 +165,17 @@ where
     }
 
     fn call_end(&mut self, context: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
-        if !self.insert_logs {
-            return;
-        }
-
-        let Some(checkpoint) = self.checkpoints.pop() else {
-            return;
-        };
-
         if outcome.result.is_ok() {
+            self.commit_transfers();
             return;
         }
 
-        self.rollback_transfers(context.journal_mut(), checkpoint);
+        self.rollback_transfers(context.journal_mut());
     }
 
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
+        self.begin_frame();
+
         let nonce = context.journal_mut().load_account(inputs.caller()).ok()?.data.info.nonce;
         let address = inputs.created_address(nonce);
 
@@ -178,7 +185,6 @@ where
             CreateScheme::Custom { .. } => return None,
         };
 
-        self.checkpoint(context);
         self.on_transfer(inputs.caller(), address, inputs.value(), kind, context.journal_mut());
 
         None
@@ -190,19 +196,12 @@ where
         _inputs: &CreateInputs,
         outcome: &mut CreateOutcome,
     ) {
-        if !self.insert_logs {
-            return;
-        }
-
-        let Some(checkpoint) = self.checkpoints.pop() else {
-            return;
-        };
-
         if outcome.result.is_ok() {
+            self.commit_transfers();
             return;
         }
 
-        self.rollback_transfers(context.journal_mut(), checkpoint);
+        self.rollback_transfers(context.journal_mut());
     }
 
     fn selfdestruct(&mut self, contract: Address, target: Address, value: U256) {
@@ -213,6 +212,13 @@ where
             value,
         });
     }
+}
+
+/// Transfer/log lengths captured before the first transfer in a frame.
+#[derive(Debug, Default, Clone, Copy)]
+struct TransferCheckpoint {
+    transfers_len: usize,
+    logs_len: usize,
 }
 
 /// A transfer operation.

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -24,6 +24,7 @@ pub const TRANSFER_EVENT_TOPIC: B256 =
 pub struct TransferInspector {
     internal_only: bool,
     transfers: Vec<TransferOperation>,
+    call_checkpoints: Vec<TransferCheckpoint>,
     /// If enabled, will insert ERC20-style transfer logs emitted by [TRANSFER_LOG_EMITTER] for
     /// each ETH transfer.
     ///
@@ -37,7 +38,12 @@ impl TransferInspector {
     /// If `internal_only` is set to `true`, only internal transfers are collected, in other words,
     /// the top level call is ignored.
     pub fn new(internal_only: bool) -> Self {
-        Self { internal_only, transfers: Vec::new(), insert_logs: false }
+        Self {
+            internal_only,
+            transfers: Vec::new(),
+            call_checkpoints: Vec::new(),
+            insert_logs: false,
+        }
     }
 
     /// Creates a new transfer inspector that only collects internal transfers.
@@ -97,11 +103,24 @@ impl TransferInspector {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+struct TransferCheckpoint {
+    transfers_len: usize,
+    logs_len: usize,
+}
+
 impl<CTX> Inspector<CTX> for TransferInspector
 where
     CTX: ContextTr,
 {
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        if self.insert_logs {
+            self.call_checkpoints.push(TransferCheckpoint {
+                transfers_len: self.transfers.len(),
+                logs_len: context.journal().logs().len(),
+            });
+        }
+
         if let Some(value) = inputs.transfer_value() {
             self.on_transfer(
                 inputs.transfer_from(),
@@ -113,6 +132,27 @@ where
         }
 
         None
+    }
+
+    fn call_end(&mut self, context: &mut CTX, _inputs: &CallInputs, outcome: &mut CallOutcome) {
+        if !self.insert_logs {
+            return;
+        }
+
+        let Some(checkpoint) = self.call_checkpoints.pop() else {
+            return;
+        };
+
+        if outcome.result.is_ok() {
+            return;
+        }
+
+        self.transfers.truncate(checkpoint.transfers_len);
+
+        let logs = context.journal_mut().take_logs();
+        for log in logs.into_iter().take(checkpoint.logs_len) {
+            context.journal_mut().log(log);
+        }
     }
 
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -24,7 +24,7 @@ pub const TRANSFER_EVENT_TOPIC: B256 =
 pub struct TransferInspector {
     internal_only: bool,
     transfers: Vec<TransferOperation>,
-    checkpoints: Vec<Option<TransferCheckpoint>>,
+    checkpoints: Vec<TransferCheckpoint>,
     /// If enabled, will insert ERC20-style transfer logs emitted by [TRANSFER_LOG_EMITTER] for
     /// each ETH transfer.
     ///
@@ -67,27 +67,12 @@ impl TransferInspector {
         self.transfers.iter()
     }
 
-    fn begin_frame(&mut self) {
+    fn begin_frame<JOURNAL: JournalTr>(&mut self, journaled_state: &JOURNAL) {
         if self.insert_logs {
-            self.checkpoints.push(None);
-        }
-    }
-
-    fn checkpoint_transfer<JOURNAL: JournalTr>(&mut self, journaled_state: &JOURNAL) {
-        if !self.insert_logs {
-            return;
-        }
-
-        let checkpoint = TransferCheckpoint {
-            transfers_len: self.transfers.len(),
-            logs_len: journaled_state.logs().len(),
-        };
-
-        for frame_checkpoint in self.checkpoints.iter_mut().rev() {
-            if frame_checkpoint.is_some() {
-                break;
-            }
-            *frame_checkpoint = Some(checkpoint);
+            self.checkpoints.push(TransferCheckpoint {
+                transfers_len: self.transfers.len(),
+                logs_len: journaled_state.logs().len(),
+            });
         }
     }
 
@@ -98,7 +83,7 @@ impl TransferInspector {
     }
 
     fn rollback_transfers<JOURNAL: JournalTr>(&mut self, journaled_state: &mut JOURNAL) {
-        let Some(checkpoint) = self.checkpoints.pop().flatten() else {
+        let Some(checkpoint) = self.checkpoints.pop() else {
             return;
         };
 
@@ -128,7 +113,6 @@ impl TransferInspector {
         if value.is_zero() {
             return;
         }
-        self.checkpoint_transfer(journaled_state);
         self.transfers.push(TransferOperation { kind, from, to, value });
 
         if self.insert_logs {
@@ -149,7 +133,7 @@ where
     CTX: ContextTr,
 {
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
-        self.begin_frame();
+        self.begin_frame(context.journal_mut());
 
         if let Some(value) = inputs.transfer_value() {
             self.on_transfer(
@@ -174,7 +158,7 @@ where
     }
 
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
-        self.begin_frame();
+        self.begin_frame(context.journal_mut());
 
         let nonce = context.journal_mut().load_account(inputs.caller()).ok()?.data.info.nonce;
         let address = inputs.created_address(nonce);

--- a/tests/it/transfer.rs
+++ b/tests/it/transfer.rs
@@ -16,7 +16,7 @@ use revm::{
 };
 use revm_inspectors::{
     tracing::{TracingInspector, TracingInspectorConfig},
-    transfer::{TransferInspector, TransferKind, TransferOperation},
+    transfer::{TransferInspector, TransferKind, TransferOperation, TRANSFER_LOG_EMITTER},
 };
 
 #[test]
@@ -111,5 +111,62 @@ fn test_internal_transfers() {
             to: deployer,
             value: U256::from(10),
         }
+    );
+}
+
+#[test]
+fn test_transfer_logs_discard_reverted_calls() {
+    // Runtime: call the caller with CALLVALUE, then revert.
+    let code = hex!("6013600c60003960136000f36000600060006000343361fffff160006000fd");
+    let deployer = Address::ZERO;
+
+    let db = CacheDB::new(EmptyDB::default());
+    let context = Context::mainnet().with_db(db).modify_cfg_chained(|c| c.spec = SpecId::LONDON);
+
+    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
+    let mut evm = context.build_mainnet_with_inspector(&mut insp);
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller: deployer,
+            gas_limit: 1000000,
+            kind: TransactTo::Create,
+            data: code.into(),
+            ..Default::default()
+        })
+        .unwrap();
+    let addr = match res.result {
+        ExecutionResult::Success { output, .. } => match output {
+            Output::Create(_, addr) => addr.unwrap(),
+            _ => panic!("Create failed"),
+        },
+        _ => panic!("Execution failed"),
+    };
+    evm.ctx().db_mut().commit(res.state);
+
+    let acc = evm.ctx().db_mut().load_account(deployer).unwrap();
+    acc.info.balance = U256::from(u64::MAX);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Call(addr),
+        value: U256::from(10),
+        nonce: 0,
+        ..Default::default()
+    };
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false));
+    let res = evm.inspect_tx(tx_env.clone().modify().nonce(1).build_fill()).unwrap();
+    assert!(!res.result.is_success());
+    assert_eq!(evm.inspector().transfers().len(), 2);
+    assert_eq!(res.result.logs().len(), 0);
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
+    let res = evm.inspect_tx(tx_env.modify().nonce(1).build_fill()).unwrap();
+    assert!(!res.result.is_success());
+    assert_eq!(evm.inspector().transfers().len(), 0);
+    assert_eq!(
+        res.result.logs().iter().filter(|log| log.address == TRANSFER_LOG_EMITTER).count(),
+        0
     );
 }

--- a/tests/it/transfer.rs
+++ b/tests/it/transfer.rs
@@ -12,6 +12,7 @@ use revm::{
     handler::EvmTr,
     inspector::InspectorEvmTr,
     primitives::hardfork::SpecId,
+    state::AccountInfo,
     Context, DatabaseCommit, InspectEvm, MainBuilder, MainContext,
 };
 use revm_inspectors::{
@@ -163,6 +164,47 @@ fn test_transfer_logs_discard_reverted_calls() {
 
     let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
     let res = evm.inspect_tx(tx_env.modify().nonce(1).build_fill()).unwrap();
+    assert!(!res.result.is_success());
+    assert_eq!(evm.inspector().transfers().len(), 0);
+    assert_eq!(
+        res.result.logs().iter().filter(|log| log.address == TRANSFER_LOG_EMITTER).count(),
+        0
+    );
+}
+
+#[test]
+fn test_transfer_logs_discard_reverted_creates() {
+    // Initcode: revert immediately.
+    let code = hex!("60006000fd");
+    let deployer = Address::ZERO;
+
+    let mut db = CacheDB::new(EmptyDB::default());
+    db.insert_account_info(
+        deployer,
+        AccountInfo { balance: U256::from(u64::MAX), ..Default::default() },
+    );
+    let context = Context::mainnet().with_db(db).modify_cfg_chained(|c| c.spec = SpecId::LONDON);
+
+    let mut evm = context.build_mainnet_with_inspector(TransferInspector::new(false));
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Create,
+        data: code.into(),
+        value: U256::from(10),
+        nonce: 0,
+        ..Default::default()
+    };
+
+    let res = evm.inspect_tx(tx_env.clone()).unwrap();
+    assert!(!res.result.is_success());
+    assert_eq!(evm.inspector().transfers().len(), 1);
+    assert_eq!(res.result.logs().len(), 0);
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
+
+    let res = evm.inspect_tx(tx_env).unwrap();
     assert!(!res.result.is_success());
     assert_eq!(evm.inspector().transfers().len(), 0);
     assert_eq!(

--- a/tests/it/transfer.rs
+++ b/tests/it/transfer.rs
@@ -282,6 +282,47 @@ fn test_transfer_logs_keep_nested_value_call_on_success() {
     assert_eq!(transfer_log_count(res.result.logs()), 1);
 }
 
+#[test]
+fn test_transfer_logs_discard_reverted_nested_selfdestruct() {
+    let deployer = Address::ZERO;
+    let beneficiary = Address::repeat_byte(0x42);
+    let mut evm = Context::mainnet().with_db(CacheDB::new(EmptyDB::default())).build_mainnet();
+
+    let mut selfdestruct_runtime = Vec::with_capacity(22);
+    selfdestruct_runtime.push(0x73);
+    selfdestruct_runtime.extend_from_slice(beneficiary.as_slice());
+    selfdestruct_runtime.push(0xff);
+
+    let target =
+        deploy_contract(&mut evm, initcode(selfdestruct_runtime), deployer, SpecId::LONDON)
+            .created_address()
+            .unwrap();
+    let caller = deploy_contract(
+        &mut evm,
+        initcode(call_target_runtime(target, 0, true)),
+        deployer,
+        SpecId::LONDON,
+    )
+    .created_address()
+    .unwrap();
+
+    evm.ctx().db_mut().load_account(target).unwrap().info.balance = U256::from(10);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Call(caller),
+        nonce: 2,
+        ..Default::default()
+    };
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
+    let res = evm.inspect_tx(tx_env).unwrap();
+    assert!(!res.result.is_success());
+    assert!(evm.inspector().transfers().is_empty());
+    assert_eq!(transfer_log_count(res.result.logs()), 0);
+}
+
 fn initcode(runtime: impl AsRef<[u8]>) -> Bytes {
     let runtime = runtime.as_ref();
     assert!(runtime.len() <= u8::MAX as usize);

--- a/tests/it/transfer.rs
+++ b/tests/it/transfer.rs
@@ -1,23 +1,20 @@
 //! Transfer tests
 
-use alloy_primitives::{hex, Address, U256};
+use crate::utils::deploy_contract;
+use alloy_primitives::{hex, Address, Bytes, Log, U256};
 use revm::{
     context::TxEnv,
-    context_interface::{
-        result::{ExecutionResult, Output},
-        ContextTr, TransactTo,
-    },
+    context_interface::{ContextTr, TransactTo},
     database::CacheDB,
     database_interface::EmptyDB,
     handler::EvmTr,
     inspector::InspectorEvmTr,
     primitives::hardfork::SpecId,
     state::AccountInfo,
-    Context, DatabaseCommit, InspectEvm, MainBuilder, MainContext,
+    Context, InspectEvm, MainBuilder, MainContext,
 };
-use revm_inspectors::{
-    tracing::{TracingInspector, TracingInspectorConfig},
-    transfer::{TransferInspector, TransferKind, TransferOperation, TRANSFER_LOG_EMITTER},
+use revm_inspectors::transfer::{
+    TransferInspector, TransferKind, TransferOperation, TRANSFER_LOG_EMITTER,
 };
 
 #[test]
@@ -38,27 +35,10 @@ fn test_internal_transfers() {
 
     let context = Context::mainnet().with_db(db).modify_cfg_chained(|c| c.spec = SpecId::LONDON);
 
-    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
-
     // Create contract
-    let mut evm = context.build_mainnet_with_inspector(&mut insp);
-    let res = evm
-        .inspect_tx(TxEnv {
-            caller: deployer,
-            gas_limit: 1000000,
-            kind: TransactTo::Create,
-            data: code.into(),
-            ..Default::default()
-        })
-        .unwrap();
-    let addr = match res.result {
-        ExecutionResult::Success { output, .. } => match output {
-            Output::Create(_, addr) => addr.unwrap(),
-            _ => panic!("Create failed"),
-        },
-        _ => panic!("Execution failed"),
-    };
-    evm.ctx().db_mut().commit(res.state);
+    let mut evm = context.build_mainnet();
+    let addr =
+        deploy_contract(&mut evm, code.into(), deployer, SpecId::LONDON).created_address().unwrap();
 
     let acc = evm.ctx().db_mut().load_account(deployer).unwrap();
     acc.info.balance = U256::from(u64::MAX);
@@ -124,25 +104,9 @@ fn test_transfer_logs_discard_reverted_calls() {
     let db = CacheDB::new(EmptyDB::default());
     let context = Context::mainnet().with_db(db).modify_cfg_chained(|c| c.spec = SpecId::LONDON);
 
-    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
-    let mut evm = context.build_mainnet_with_inspector(&mut insp);
-    let res = evm
-        .inspect_tx(TxEnv {
-            caller: deployer,
-            gas_limit: 1000000,
-            kind: TransactTo::Create,
-            data: code.into(),
-            ..Default::default()
-        })
-        .unwrap();
-    let addr = match res.result {
-        ExecutionResult::Success { output, .. } => match output {
-            Output::Create(_, addr) => addr.unwrap(),
-            _ => panic!("Create failed"),
-        },
-        _ => panic!("Execution failed"),
-    };
-    evm.ctx().db_mut().commit(res.state);
+    let mut evm = context.build_mainnet();
+    let addr =
+        deploy_contract(&mut evm, code.into(), deployer, SpecId::LONDON).created_address().unwrap();
 
     let acc = evm.ctx().db_mut().load_account(deployer).unwrap();
     acc.info.balance = U256::from(u64::MAX);
@@ -166,10 +130,7 @@ fn test_transfer_logs_discard_reverted_calls() {
     let res = evm.inspect_tx(tx_env.modify().nonce(1).build_fill()).unwrap();
     assert!(!res.result.is_success());
     assert_eq!(evm.inspector().transfers().len(), 0);
-    assert_eq!(
-        res.result.logs().iter().filter(|log| log.address == TRANSFER_LOG_EMITTER).count(),
-        0
-    );
+    assert_eq!(transfer_log_count(res.result.logs()), 0);
 }
 
 #[test]
@@ -207,8 +168,148 @@ fn test_transfer_logs_discard_reverted_creates() {
     let res = evm.inspect_tx(tx_env).unwrap();
     assert!(!res.result.is_success());
     assert_eq!(evm.inspector().transfers().len(), 0);
+    assert_eq!(transfer_log_count(res.result.logs()), 0);
+}
+
+#[test]
+fn test_transfer_logs_discard_reverted_value_call_with_nested_zero_call() {
+    let deployer = Address::ZERO;
+    let mut evm = Context::mainnet().with_db(CacheDB::new(EmptyDB::default())).build_mainnet();
+
+    let target = deploy_contract(&mut evm, initcode([0x00]), deployer, SpecId::LONDON)
+        .created_address()
+        .unwrap();
+    let caller = deploy_contract(
+        &mut evm,
+        initcode(call_target_runtime(target, 0, true)),
+        deployer,
+        SpecId::LONDON,
+    )
+    .created_address()
+    .unwrap();
+
+    evm.ctx().db_mut().load_account(deployer).unwrap().info.balance = U256::from(u64::MAX);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Call(caller),
+        value: U256::from(10),
+        nonce: 2,
+        ..Default::default()
+    };
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
+    let res = evm.inspect_tx(tx_env).unwrap();
+    assert!(!res.result.is_success());
+    assert!(evm.inspector().transfers().is_empty());
+    assert_eq!(transfer_log_count(res.result.logs()), 0);
+}
+
+#[test]
+fn test_transfer_logs_discard_reverted_nested_value_call() {
+    let deployer = Address::ZERO;
+    let mut evm = Context::mainnet().with_db(CacheDB::new(EmptyDB::default())).build_mainnet();
+
+    let target = deploy_contract(&mut evm, initcode([0x00]), deployer, SpecId::LONDON)
+        .created_address()
+        .unwrap();
+    let caller = deploy_contract(
+        &mut evm,
+        initcode(call_target_runtime(target, 10, true)),
+        deployer,
+        SpecId::LONDON,
+    )
+    .created_address()
+    .unwrap();
+
+    evm.ctx().db_mut().load_account(caller).unwrap().info.balance = U256::from(10);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Call(caller),
+        nonce: 2,
+        ..Default::default()
+    };
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
+    let res = evm.inspect_tx(tx_env).unwrap();
+    assert!(!res.result.is_success());
+    assert!(evm.inspector().transfers().is_empty());
+    assert_eq!(transfer_log_count(res.result.logs()), 0);
+}
+
+#[test]
+fn test_transfer_logs_keep_nested_value_call_on_success() {
+    let deployer = Address::ZERO;
+    let mut evm = Context::mainnet().with_db(CacheDB::new(EmptyDB::default())).build_mainnet();
+
+    let target = deploy_contract(&mut evm, initcode([0x00]), deployer, SpecId::LONDON)
+        .created_address()
+        .unwrap();
+    let caller = deploy_contract(
+        &mut evm,
+        initcode(call_target_runtime(target, 10, false)),
+        deployer,
+        SpecId::LONDON,
+    )
+    .created_address()
+    .unwrap();
+
+    evm.ctx().db_mut().load_account(caller).unwrap().info.balance = U256::from(10);
+
+    let tx_env = TxEnv {
+        caller: deployer,
+        gas_limit: 1000000,
+        kind: TransactTo::Call(caller),
+        nonce: 2,
+        ..Default::default()
+    };
+
+    let mut evm = evm.with_inspector(TransferInspector::new(false).with_logs(true));
+    let res = evm.inspect_tx(tx_env).unwrap();
+    assert!(res.result.is_success());
     assert_eq!(
-        res.result.logs().iter().filter(|log| log.address == TRANSFER_LOG_EMITTER).count(),
-        0
+        evm.inspector().transfers(),
+        &[TransferOperation {
+            kind: TransferKind::Call,
+            from: caller,
+            to: target,
+            value: U256::from(10),
+        }]
     );
+    assert_eq!(transfer_log_count(res.result.logs()), 1);
+}
+
+fn initcode(runtime: impl AsRef<[u8]>) -> Bytes {
+    let runtime = runtime.as_ref();
+    assert!(runtime.len() <= u8::MAX as usize);
+
+    let len = runtime.len() as u8;
+    let mut code = Vec::with_capacity(12 + runtime.len());
+    code.extend_from_slice(&[0x60, len, 0x60, 0x0c, 0x60, 0x00, 0x39]);
+    code.extend_from_slice(&[0x60, len, 0x60, 0x00, 0xf3]);
+    code.extend_from_slice(runtime);
+    code.into()
+}
+
+fn call_target_runtime(target: Address, value: u8, revert: bool) -> Bytes {
+    let mut runtime = Vec::with_capacity(40);
+    runtime.extend_from_slice(&[0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, 0x00, 0x60, value]);
+    runtime.push(0x73);
+    runtime.extend_from_slice(target.as_slice());
+    runtime.extend_from_slice(&[0x61, 0xff, 0xff, 0xf1, 0x50]);
+
+    if revert {
+        runtime.extend_from_slice(&[0x60, 0x00, 0x60, 0x00, 0xfd]);
+    } else {
+        runtime.push(0x00);
+    }
+
+    runtime.into()
+}
+
+fn transfer_log_count(logs: &[Log]) -> usize {
+    logs.iter().filter(|log| log.address == TRANSFER_LOG_EMITTER).count()
 }


### PR DESCRIPTION
Updates `TransferInspector` so synthetic transfer-log mode cleans up frame-local transfers/logs when `CALL` or `CREATE` frames revert or halt.

This keeps `TransferInspector::with_logs(true)` aligned with EVM revert semantics: transfer logs inserted for failed frames are removed instead of leaking into the final execution result.

## Details

- Adds frame checkpoints to `TransferInspector` when synthetic log insertion is enabled.
- On `call_end` / `create_end`, successful outcomes keep collected transfers/logs.
- Reverted or halted outcomes roll back:
  - collected transfer operations
  - synthetic logs inserted into the journal
- Adds regression coverage for reverted `CALL` and reverted `CREATE`.

## Why

`eth_simulateV1 traceTransfers` represents ETH transfers as synthetic ERC20-style logs. These logs are RPC artifacts, not contract-emitted logs, so failed internal frames should not leak them into successful parent results.

