### PR TITLE
ci: allow proc-macro-error2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,6 +4,9 @@ yanked = "warn"
 ignore = [
     # https://rustsec.org/advisories/RUSTSEC-2024-0436
     "RUSTSEC-2024-0436",
+    # proc-macro-error2 is pulled in through alloy-sol-types; no safe upgrade is available yet.
+    # https://rustsec.org/advisories/RUSTSEC-2026-0173
+    "RUSTSEC-2026-0173",
 ]
 
 [bans]


### PR DESCRIPTION
## Summary

Adds `RUSTSEC-2026-0173` to the cargo-deny advisory ignore list.

## Context

The `deny / cargo deny check` job is failing because `proc-macro-error2` is now marked unmaintained. The dependency is currently pulled in transitively through `alloy-sol-types` / `alloy-sol-macro`, and the advisory reports that no safe upgrade is available yet.

## Impact

This restores the deny baseline while keeping the advisory explicit in `deny.toml` so it can be removed once the transitive dependency is eliminated upstream.