### PR TITLE
fix: track the transaction-wide refund counter in traces

### DIFF
--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -78,6 +78,19 @@ pub struct TracingInspector {
     traces: CallTraceArena,
     /// Tracks active calls
     trace_stack: Vec<usize>,
+    /// For each active frame, the transaction-wide gas refund accumulated by its ancestor
+    /// frames when the frame started. Kept in sync with `trace_stack`.
+    ///
+    /// revm's `Gas::refunded()` is local to a frame and can go negative (e.g. when a frame
+    /// re-sets a storage slot that an outer frame cleared), while geth reports a single
+    /// transaction-wide counter in its traces. The global counter for the current frame is
+    /// `frame_refund_stack.last() + interp.gas.refunded()`.
+    frame_refund_stack: Vec<i64>,
+    /// The most recent `Gas::refunded()` value observed for the currently executing frame.
+    ///
+    /// Used to seed `frame_refund_stack` when a child frame starts, since the call and
+    /// create hooks don't have access to the parent interpreter.
+    last_frame_refund: i64,
     /// Tracks whether the next `step_end` should be recorded. Set in `start_step`.
     record_step_end: bool,
     /// Tracks the return value of the last call
@@ -109,6 +122,8 @@ impl TracingInspector {
         let Self {
             traces,
             trace_stack,
+            frame_refund_stack,
+            last_frame_refund,
             last_call_return_data,
             last_journal_len,
             spec_id,
@@ -131,6 +146,8 @@ impl TracingInspector {
 
         traces.clear();
         trace_stack.clear();
+        frame_refund_stack.clear();
+        *last_frame_refund = 0;
         last_call_return_data.take();
         spec_id.take();
         *last_journal_len = 0;
@@ -358,6 +375,13 @@ impl TracingInspector {
         // find an empty steps vec or create a new one
         let steps = self.reusable_step_vecs.pop().unwrap_or_default();
 
+        // Seed the new frame with the transaction-wide refund accumulated so far: the refund
+        // the ancestors had when the parent frame started, plus the parent's own counter as
+        // of its last observed step. The root frame starts at zero.
+        let ancestor_refund =
+            self.frame_refund_stack.last().map_or(0, |anc| anc + self.last_frame_refund);
+        self.frame_refund_stack.push(ancestor_refund);
+
         self.trace_stack.push(self.traces.push_trace(
             0,
             push_kind,
@@ -392,10 +416,19 @@ impl TracingInspector {
         let InterpreterResult { result, ref output, ref gas } = *result;
 
         let trace_idx = self.pop_trace_idx();
+        let ancestor_refund =
+            self.frame_refund_stack.pop().expect("more traces were filled than started");
         let trace = &mut self.traces.arena[trace_idx].trace;
 
         trace.gas_used = gas.total_gas_spent();
-        trace.gas_refund_counter = gas.refunded().max(0) as u64;
+        // The transaction-wide refund counter at the end of this call. The frame's own
+        // refund only counts if it succeeded: revm merges a child's refund into the parent
+        // on success only (see `EthFrame::return_result`), and geth rewinds its global
+        // counter via the journal when a frame reverts.
+        let tx_refund =
+            if result.is_ok() { ancestor_refund + gas.refunded() } else { ancestor_refund };
+        debug_assert!(tx_refund >= 0, "transaction-wide refund counter must not go negative");
+        trace.gas_refund_counter = tx_refund.max(0) as u64;
 
         trace.status = Some(result);
         trace.success = trace.status.is_some_and(|status| status.is_ok());
@@ -465,11 +498,16 @@ impl TracingInspector {
             Bytes::new()
         };
 
-        let gas_used = gas_used(
-            interp.runtime_flag.spec_id(),
-            interp.gas.total_gas_spent(),
-            interp.gas.refunded() as u64,
-        );
+        // The transaction-wide refund counter as of before this step executes. This mirrors
+        // geth, whose struct logger reads the global counter before each opcode. The frame's
+        // own `Gas::refunded()` can be negative and is meaningless in isolation, see
+        // `Self::frame_refund_stack`.
+        let tx_refund = (self.frame_refund_stack.last().copied().unwrap_or(0)
+            + interp.gas.refunded())
+        .max(0) as u64;
+
+        let gas_used =
+            gas_used(interp.runtime_flag.spec_id(), interp.gas.total_gas_spent(), tx_refund);
 
         let mut immediate_bytes = None;
         if self.config.record_immediate_bytes {
@@ -491,7 +529,7 @@ impl TracingInspector {
             memory,
             returndata,
             gas_remaining: interp.gas.remaining(),
-            gas_refund_counter: interp.gas.refunded() as u64,
+            gas_refund_counter: tx_refund,
             gas_used,
             immediate_bytes,
 
@@ -603,6 +641,7 @@ where
 {
     #[inline]
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
+        self.last_frame_refund = interp.gas.refunded();
         if self.config.record_steps {
             self.start_step(interp, context);
         }
@@ -610,6 +649,10 @@ where
 
     #[inline]
     fn step_end(&mut self, interp: &mut Interpreter, context: &mut CTX) {
+        // Refresh after the opcode ran: SSTORE and SELFDESTRUCT record refunds during
+        // execution, and a CALL or CREATE spawning next reads this value when seeding the
+        // child frame in `start_trace_on_call`.
+        self.last_frame_refund = interp.gas.refunded();
         if self.config.record_steps {
             self.fill_step_on_step_end(interp, context);
         }

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -97,6 +97,9 @@ pub struct CallTrace {
     /// The gas limit of the call.
     pub gas_limit: u64,
     /// The cumulative refund counter for the entire transaction context at the end of this call.
+    ///
+    /// A frame that did not succeed contributes nothing: its refunds are discarded, like
+    /// geth rewinding its global counter when a frame reverts.
     pub gas_refund_counter: u64,
     /// The final status of the call.
     pub status: Option<InstructionResult>,
@@ -677,7 +680,8 @@ pub struct CallTraceStep {
     pub returndata: Bytes,
     /// Remaining gas before step execution
     pub gas_remaining: u64,
-    /// Gas refund counter before step execution
+    /// The transaction-wide gas refund counter before step execution, matching the `refund`
+    /// field of geth's struct logs
     pub gas_refund_counter: u64,
     /// Total gas used before step execution
     pub gas_used: u64,

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -1,6 +1,6 @@
 //! Geth tests
 use crate::utils::deploy_contract;
-use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256};
+use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256, U256};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     erc7562::Erc7562Config, mux::MuxConfig, CallConfig, FlatCallConfig, GethDebugBuiltInTracerType,
@@ -1182,4 +1182,281 @@ fn test_geth_calltracer_logs_delegatecall() {
         Some(implementation),
         "Log emitter must NOT be the implementation (bytecode) address"
     );
+}
+
+/// Executes `code` at `target` with the given accounts pre-seeded (committed storage, so
+/// `original` slot values are non-zero where set) under a default geth tracing inspector.
+///
+/// Returns the `(opcode, refund_counter)` sequence of the struct logs and the
+/// `gas_refund_counter` of every recorded call trace, in arena order.
+/// An account pre-seeded for a refund scenario: address, runtime code, and committed
+/// storage slots.
+type SeededAccount<'a> = (Address, &'a [u8], &'a [(u64, u64)]);
+
+fn trace_refund_scenario(
+    accounts: &[SeededAccount<'_>],
+    target: Address,
+) -> (Vec<(String, u64)>, Vec<u64>) {
+    let caller = address!("00000000000000000000000000000000000c0ffe");
+    let context =
+        Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+            for (addr, code, slots) in accounts {
+                db.insert_account_info(
+                    *addr,
+                    AccountInfo {
+                        code: Some(Bytecode::new_raw(Bytes::copy_from_slice(code))),
+                        ..Default::default()
+                    },
+                );
+                for (slot, value) in *slots {
+                    db.insert_account_storage(*addr, U256::from(*slot), U256::from(*value))
+                        .unwrap();
+                }
+            }
+        });
+
+    let mut insp = TracingInspector::new(TracingInspectorConfig::default_geth());
+    let mut evm = context.build_mainnet().with_inspector(&mut insp);
+    evm.ctx().modify_cfg(|cfg| cfg.spec = SpecId::CANCUN);
+
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 1_000_000,
+            kind: TransactTo::Call(target),
+            data: Bytes::default(),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "transaction should succeed: {res:#?}");
+
+    let refunds = insp.traces().nodes().iter().map(|n| n.trace.gas_refund_counter).collect();
+    let frame =
+        insp.with_transaction_gas_used(res.result.tx_gas_used()).geth_builder().geth_traces(
+            res.result.tx_gas_used(),
+            res.result.output().unwrap_or_default().clone(),
+            GethDefaultTracingOptions::default(),
+        );
+    let steps = frame
+        .struct_logs
+        .iter()
+        .map(|l| (l.op.to_string(), l.refund_counter.unwrap_or(0)))
+        .collect();
+    (steps, refunds)
+}
+
+#[test]
+fn test_geth_structlog_refund_counter_nested_call() {
+    // Regression test for the per-frame refund underflow (issue #267, reth#14783).
+    //
+    // Contract at `target`, storage slot 0 committed to 1:
+    //   outer frame: SSTORE(0, 0)        clears the slot, +4800 refund (EIP-3529)
+    //                CALL(self, 1 byte)  enters the inner frame
+    //   inner frame: SSTORE(0, 1)        re-sets the cleared slot: -4800 + 2800 = -2000,
+    //                                    so this frame's own counter is negative
+    //                STOP
+    //
+    // geth reports the transaction-wide refund counter as of before each opcode, so the
+    // inner frame must show the refund accumulated by its parent (4800), and the STOP
+    // after the re-set must show 2800, not a value underflowed by the `as u64` cast.
+    //
+    // 0x00: CALLDATASIZE PUSH1 0x18 JUMPI            inner frame jumps (1 byte calldata)
+    // 0x04: PUSH1 0 PUSH1 0 SSTORE                   clear slot 0
+    // 0x09: PUSH1 0 PUSH1 0 PUSH1 1 PUSH1 0 PUSH1 0  ret/args/value for the self-call
+    // 0x13: ADDRESS GAS CALL POP STOP
+    // 0x18: JUMPDEST PUSH1 1 PUSH1 0 SSTORE STOP     re-set slot 0
+    let target = address!("0000000000000000000000000000000000000aaa");
+    let code = hex!("36601857600060005560006000600160006000305af150005b600160005500");
+
+    let (steps, refunds) = trace_refund_scenario(&[(target, &code, &[(0, 1)])], target);
+
+    let expected: Vec<(String, u64)> = [
+        ("CALLDATASIZE", 0),
+        ("PUSH1", 0),
+        ("JUMPI", 0),
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("SSTORE", 0),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("ADDRESS", 4800),
+        ("GAS", 4800),
+        ("CALL", 4800),
+        // inner frame, which re-runs the dispatch preamble before jumping
+        ("CALLDATASIZE", 4800),
+        ("PUSH1", 4800),
+        ("JUMPI", 4800),
+        ("JUMPDEST", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("SSTORE", 4800),
+        ("STOP", 2800),
+        // back in the outer frame
+        ("POP", 2800),
+        ("STOP", 2800),
+    ]
+    .iter()
+    .map(|(op, refund)| (op.to_string(), *refund))
+    .collect();
+    assert_eq!(steps, expected);
+
+    // Both frames end the transaction with the same global counter.
+    assert_eq!(refunds, vec![2800, 2800]);
+}
+
+#[test]
+fn test_geth_structlog_refund_counter_reverted_call() {
+    // Same scenario as test_geth_structlog_refund_counter_nested_call, but the inner
+    // frame reverts after re-setting the slot. revm only merges a child's refund into the
+    // parent on success, mirroring geth's journal rewind, so after the revert the counter
+    // must come back to 4800. The reverted frame's call trace reports the counter as of
+    // its end, 4800 as well, since its own refund delta is discarded.
+    let target = address!("0000000000000000000000000000000000000aaa");
+    let code = hex!("36601857600060005560006000600160006000305af150005b600160005560006000fd");
+
+    let (steps, refunds) = trace_refund_scenario(&[(target, &code, &[(0, 1)])], target);
+
+    let expected: Vec<(String, u64)> = [
+        ("CALLDATASIZE", 0),
+        ("PUSH1", 0),
+        ("JUMPI", 0),
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("SSTORE", 0),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("ADDRESS", 4800),
+        ("GAS", 4800),
+        ("CALL", 4800),
+        // inner frame, which re-runs the dispatch preamble before jumping
+        ("CALLDATASIZE", 4800),
+        ("PUSH1", 4800),
+        ("JUMPI", 4800),
+        ("JUMPDEST", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("SSTORE", 4800),
+        ("PUSH1", 2800),
+        ("PUSH1", 2800),
+        ("REVERT", 2800),
+        // back in the outer frame, the reverted refund delta is discarded
+        ("POP", 4800),
+        ("STOP", 4800),
+    ]
+    .iter()
+    .map(|(op, refund)| (op.to_string(), *refund))
+    .collect();
+    assert_eq!(steps, expected);
+
+    assert_eq!(refunds, vec![4800, 4800]);
+}
+
+#[test]
+fn test_geth_structlog_refund_counter_sibling_calls() {
+    // Two sibling calls each clear a slot in their own storage (+4800 each). The global
+    // counter must accumulate across siblings: 4800 inside and after the first child,
+    // 9600 inside and after the second. This also guards against double counting: once
+    // the parent absorbs the first child's refund, that refund must not be added again
+    // when the second child starts.
+    let target = address!("0000000000000000000000000000000000000a0a");
+    let child1 = address!("0000000000000000000000000000000000000b01");
+    let child2 = address!("0000000000000000000000000000000000000b02");
+    // PUSH1 0 x4, PUSH1 0 (value), PUSH20 <child>, GAS, CALL, POP, twice, then STOP
+    let parent_code = hex!(
+        "60006000600060006000730000000000000000000000000000000000000b015af150"
+        "60006000600060006000730000000000000000000000000000000000000b025af150"
+        "00"
+    );
+    // PUSH1 0 PUSH1 0 SSTORE STOP, clears slot 0 of the executing contract
+    let child_code = hex!("600060005500");
+
+    let (steps, refunds) = trace_refund_scenario(
+        &[
+            (target, &parent_code, &[]),
+            (child1, &child_code, &[(0, 1)]),
+            (child2, &child_code, &[(0, 1)]),
+        ],
+        target,
+    );
+
+    let expected: Vec<(String, u64)> = [
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("PUSH20", 0),
+        ("GAS", 0),
+        ("CALL", 0),
+        // first child
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("SSTORE", 0),
+        ("STOP", 4800),
+        // back in the parent
+        ("POP", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH20", 4800),
+        ("GAS", 4800),
+        ("CALL", 4800),
+        // second child
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("SSTORE", 4800),
+        ("STOP", 9600),
+        // back in the parent
+        ("POP", 9600),
+        ("STOP", 9600),
+    ]
+    .iter()
+    .map(|(op, refund)| (op.to_string(), *refund))
+    .collect();
+    assert_eq!(steps, expected);
+
+    assert_eq!(refunds, vec![9600, 4800, 9600]);
+}
+
+#[test]
+fn test_geth_structlog_refund_counter_create() {
+    // The refund accumulated before a CREATE must be visible inside the initcode frame
+    // and in the created frame's call trace (covers the create/create_end path).
+    //
+    // PUSH1 0 PUSH1 0 SSTORE          clears slot 0, +4800
+    // PUSH1 1 PUSH1 0 PUSH1 0 CREATE  initcode is the single zero byte at memory 0, STOP
+    // POP STOP
+    let target = address!("0000000000000000000000000000000000000ccc");
+    let code = hex!("6000600055600160006000f05000");
+
+    let (steps, refunds) = trace_refund_scenario(&[(target, &code, &[(0, 1)])], target);
+
+    let expected: Vec<(String, u64)> = [
+        ("PUSH1", 0),
+        ("PUSH1", 0),
+        ("SSTORE", 0),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("PUSH1", 4800),
+        ("CREATE", 4800),
+        // initcode frame
+        ("STOP", 4800),
+        // back in the outer frame
+        ("POP", 4800),
+        ("STOP", 4800),
+    ]
+    .iter()
+    .map(|(op, refund)| (op.to_string(), *refund))
+    .collect();
+    assert_eq!(steps, expected);
+
+    assert_eq!(refunds, vec![4800, 4800]);
 }


### PR DESCRIPTION
Fixes #267

`Gas::refunded()` is local to the current frame: every frame starts at 0, and revm only merges a child's counter into its parent on success (`EthFrame::return_result`). geth instead tracks a single transaction-wide counter (`StateDB.GetRefund`), and that is what its struct logs expose.

The tracer currently records `interp.gas.refunded() as u64` per step. A frame's local counter can be negative, e.g. when a frame re-sets a storage slot that an outer frame cleared (-4800 + 2800 with EIP-3529 values), so the cast underflows to values like 18446744073709549616. This is the bug reported in paradigmxyz/reth#14783. The same per-frame value also feeds `utils::gas_used` (where the underflow is silently masked by the `min(spent / quotient)` cap), and, clamped to zero, `CallTrace::gas_refund_counter`, whose doc already promises "the cumulative refund counter for the entire transaction context".

## Solution

Reconstruct the transaction-wide counter in the inspector with a prefix-sum stack kept in sync with `trace_stack`:

- `frame_refund_stack: Vec<i64>`: for each active frame, the tx-wide refund its ancestors had accumulated when the frame started. Pushed in `start_trace_on_call` (covers calls and creates), popped in `fill_trace_on_call_end`.
- `last_frame_refund: i64`: the parent's `refunded()` as of its last observed step, used to seed a child frame since the call and create hooks don't get the parent interpreter. Refreshed in `step` and `step_end` outside the `record_steps` gate, so call traces stay correct for configs that don't record steps.

The counter for the current frame at any point is `frame_refund_stack.last() + interp.gas.refunded()`. On `call_end` the frame's own refund only counts if the frame succeeded, mirroring both `return_result` (revm merges on `is_ok()` only) and geth's journal rewind on revert.

Notes on the sketch in #267, where this PR deviates and why:

- The accumulator cannot be a single scalar that adds `outcome.gas().refunded()` on `call_end` (as drafted in #268): on success the parent also absorbs the child's refund into its own `refunded()`, so `global + interp.gas.refunded()` would count every returned child twice. The sibling-calls test below kills that variant (the parent's steps after each return would read 9600 and 19200 instead of 4800 and 9600).
- The capture stays in `step` (pre-opcode) instead of moving to `step_end`: geth's struct logger reads `GetRefund()` in `OnOpcode` ([logger.go#L290](https://github.com/ethereum/go-ethereum/blob/43b7b4e8d9f9c8bf74d27bc6b13cb6c90a6128f8/eth/tracers/logger/logger.go#L290)), which runs before the opcode executes ([interpreter.go#L245](https://github.com/ethereum/go-ethereum/blob/43b7b4e8d9f9c8bf74d27bc6b13cb6c90a6128f8/core/vm/interpreter.go#L245)), so the value shown for an SSTORE step is the counter before that SSTORE applies.
- `gas_refund_counter` stays `u64`: the tx-wide counter never goes negative (geth's is a `uint64` ([logger.go#L69](https://github.com/ethereum/go-ethereum/blob/43b7b4e8d9f9c8bf74d27bc6b13cb6c90a6128f8/eth/tracers/logger/logger.go#L69)) and `SubRefund` panics on underflow ([statedb.go#L307-L311](https://github.com/ethereum/go-ethereum/blob/43b7b4e8d9f9c8bf74d27bc6b13cb6c90a6128f8/core/state/statedb.go#L307-L311)); every SSTORE refund decrement is paired with an earlier non-reverted increment in the same transaction). Negativity is a revm per-frame artifact that should not leak into the API, and `i64` would break downstream consumers that sum this field into a `u64`. A `debug_assert` guards the invariant.

Happy to flip any of these if you would rather stick to the sketch; each one is a small localized change.

Observable changes: struct log `refund` values inside nested frames are now transaction-wide (no more underflow), and `CallTrace::gas_refund_counter` of nested and reverted frames now matches its documented semantics. Top-level values of successful transactions are unchanged. Checked the two main consumers: reth never reads `CallTrace::gas_refund_counter` (it consumes struct logs and pins no refund values in test data), and foundry reads it only at `depth <= 0` (`<= 1` with `--isolate`) in `folded_stack_trace.rs`, where values are unchanged for successful transactions.

Out of scope, can follow up: the JS tracer does the same cast (`src/tracing/js/mod.rs`), and `refund` omitempty parity with geth's legacy format.

## Tests

Four tests assert the full `(opcode, refund)` struct log sequence plus every `CallTrace::gas_refund_counter`, with EIP-3529 values computed by hand:

- nested call: the outer frame clears a slot (+4800), the inner frame re-sets it (-2000 local). Before the fix the inner STOP step reports 18446744073709549616.
- reverted inner frame: the discarded refund must come back to 4800 after the revert, and the reverted frame's trace reports 4800.
- two sibling calls (+4800 each): 4800 then 9600, inside the children and after each return. Guards against double counting.
- create: the refund accumulated before CREATE is visible inside the initcode frame and in the created frame's trace (covers `create_end`).
