### PR TITLE
chore: bump revm to 41.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "40.0.0", default-features = false }
+revm = { version = "41.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
Bumps revm from 40.0.0 to 41.0.0.

Compiles clean with `--all-features` and all tests pass — no API changes required.