### PR TITLE
feat(mux): support JS tracers in the mux tracer

### DIFF
--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -63,7 +63,7 @@ impl DebugInspector {
                 Self::PreStateTracer(inspector.clone(), *config)
             }
             Self::Noop(inspector) => Self::Noop(*inspector),
-            Self::Mux(inspector, config) => Self::Mux(inspector.clone(), config.clone()),
+            Self::Mux(inspector, config) => Self::Mux(inspector.try_clone()?, config.clone()),
             Self::FlatCallTracer(inspector) => Self::FlatCallTracer(inspector.clone()),
             Self::Erc7562Tracer(inspector, config) => {
                 Self::Erc7562Tracer(inspector.clone(), config.clone())
@@ -235,10 +235,31 @@ impl DebugInspector {
                     .into()
             }
             Self::Noop(_) => NoopFrame::default().into(),
-            Self::Mux(inspector, _) => inspector
-                .try_into_mux_frame(res, db, tx_info)
-                .map_err(DebugInspectorError::Database)?
-                .into(),
+            Self::Mux(inspector, _) => {
+                #[cfg(feature = "js-tracer")]
+                let frame = inspector
+                    .try_into_mux_frame_with_js(
+                        res,
+                        tx_env,
+                        block_env,
+                        db,
+                        tx_info,
+                        tx_context.unwrap_or_default(),
+                    )
+                    .map_err(|err| match err {
+                        crate::tracing::MuxJsFrameError::Database(err) => {
+                            DebugInspectorError::Database(err)
+                        }
+                        crate::tracing::MuxJsFrameError::Js(err) => {
+                            DebugInspectorError::JsInspector(err)
+                        }
+                    })?;
+                #[cfg(not(feature = "js-tracer"))]
+                let frame = inspector
+                    .try_into_mux_frame(res, db, tx_info)
+                    .map_err(DebugInspectorError::Database)?;
+                frame.into()
+            }
             Self::FlatCallTracer(inspector) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
                 inspector.set_transaction_caller(tx_env.caller());

--- a/src/tracing/js/mod.rs
+++ b/src/tracing/js/mod.rs
@@ -264,6 +264,11 @@ impl JsInspector {
         &self.transaction_context
     }
 
+    /// Returns the JS code this inspector was created with.
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+
     /// Sets the transaction context.
     pub fn set_transaction_context(&mut self, transaction_context: TransactionContext) {
         self.transaction_context = transaction_context;

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -57,6 +57,8 @@ pub use writer::{TraceWriter, TraceWriterConfig};
 pub mod js;
 
 mod mux;
+#[cfg(feature = "js-tracer")]
+pub use mux::MuxJsFrameError;
 pub use mux::{Error as MuxError, MuxInspector};
 
 mod debug;

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -19,13 +19,25 @@ use revm::{
 };
 use thiserror::Error;
 
+#[cfg(feature = "js-tracer")]
+use crate::tracing::{js::JsInspector, TransactionContext};
+#[cfg(feature = "js-tracer")]
+use alloc::string::ToString;
+#[cfg(feature = "js-tracer")]
+use alloy_rpc_types_trace::geth::GethTrace;
+#[cfg(feature = "js-tracer")]
+use revm::context_interface::{Block, Transaction};
+
 /// Mux tracing inspector that runs and collects results of multiple inspectors at once.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MuxInspector {
     /// An instance of FourByteInspector that can be reused
     four_byte: Option<FourByteInspector>,
     /// An instance of TracingInspector that can be reused
     tracing: Option<TracingInspector>,
+    /// One JS inspector per JS tracer key in the mux config
+    #[cfg(feature = "js-tracer")]
+    js: Vec<JsInspector>,
     /// Configurations for different Geth trace types
     configs: Vec<(GethDebugBuiltInTracerType, TraceConfig)>,
 }
@@ -45,11 +57,21 @@ impl MuxInspector {
         let mut four_byte = None;
         let mut inspector_config = TracingInspectorConfig::none();
         let mut configs = Vec::new();
+        #[cfg(feature = "js-tracer")]
+        let mut js = Vec::new();
 
         // Process each tracer configuration
         for (tracer_type, tracer_config) in config.0 {
             let builtin = match tracer_type {
                 GethDebugTracerType::BuiltInTracer(b) => b,
+                #[cfg(feature = "js-tracer")]
+                GethDebugTracerType::JsTracer(code) => {
+                    let config =
+                        tracer_config.map(|c| c.into_json()).unwrap_or(serde_json::Value::Null);
+                    js.push(JsInspector::new(code, config)?);
+                    continue;
+                }
+                #[cfg(not(feature = "js-tracer"))]
                 _ => return Err(Error::UnsupportedTracerType(tracer_type)),
             };
             #[allow(unreachable_patterns)]
@@ -104,7 +126,27 @@ impl MuxInspector {
 
         let tracing = (!configs.is_empty()).then(|| TracingInspector::new(inspector_config));
 
-        Ok(MuxInspector { four_byte, tracing, configs })
+        Ok(MuxInspector {
+            four_byte,
+            tracing,
+            #[cfg(feature = "js-tracer")]
+            js,
+            configs,
+        })
+    }
+
+    /// Attempts to create a copy of this inspector.
+    ///
+    /// This is fallible because JS tracers cannot be cloned and are re-created from their
+    /// original code instead.
+    pub fn try_clone(&self) -> Result<Self, Error> {
+        Ok(Self {
+            four_byte: self.four_byte.clone(),
+            tracing: self.tracing.clone(),
+            #[cfg(feature = "js-tracer")]
+            js: self.js.iter().map(JsInspector::try_clone).collect::<Result<_, _>>()?,
+            configs: self.configs.clone(),
+        })
     }
 
     /// Try converting this [MuxInspector] into a [MuxFrame].
@@ -165,6 +207,37 @@ impl MuxInspector {
 
         Ok(MuxFrame(frame))
     }
+
+    /// Same as [`Self::try_into_mux_frame`], but additionally resolves any configured JS
+    /// tracers into the frame, keyed by their original code as
+    /// [`GethDebugTracerType::JsTracer`].
+    #[cfg(feature = "js-tracer")]
+    pub fn try_into_mux_frame_with_js<DB: DatabaseRef>(
+        &mut self,
+        result: &ResultAndState<impl HaltReasonTr>,
+        tx: &impl Transaction,
+        block: &impl Block,
+        db: &DB,
+        tx_info: TransactionInfo,
+        tx_context: TransactionContext,
+    ) -> Result<MuxFrame, MuxJsFrameError<DB::Error>>
+    where
+        DB::Error: core::fmt::Display,
+    {
+        let mut frame =
+            self.try_into_mux_frame(result, db, tx_info).map_err(MuxJsFrameError::Database)?;
+
+        for inspector in &mut self.js {
+            inspector.set_transaction_context(tx_context);
+            let value = inspector.json_result(result.clone(), tx, block, db)?;
+            frame.0.insert(
+                GethDebugTracerType::JsTracer(inspector.code().to_string()),
+                GethTrace::JS(value),
+            );
+        }
+
+        Ok(frame)
+    }
 }
 
 impl<CTX> Inspector<CTX> for MuxInspector
@@ -189,6 +262,10 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.step(interp, context);
         }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
+            inspector.step(interp, context);
+        }
     }
 
     #[inline]
@@ -197,6 +274,10 @@ where
             inspector.step_end(interp, context);
         }
         if let Some(ref mut inspector) = self.tracing {
+            inspector.step_end(interp, context);
+        }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
             inspector.step_end(interp, context);
         }
     }
@@ -226,6 +307,10 @@ where
         if let Some(ref mut inspector) = self.four_byte {
             let _ = inspector.call(context, inputs);
         }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
+            let _ = inspector.call(context, inputs);
+        }
         if let Some(ref mut inspector) = self.tracing {
             return inspector.call(context, inputs);
         }
@@ -240,11 +325,19 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.call_end(context, inputs, outcome);
         }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
+            inspector.call_end(context, inputs, outcome);
+        }
     }
 
     #[inline]
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
         if let Some(ref mut inspector) = self.four_byte {
+            let _ = inspector.create(context, inputs);
+        }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
             let _ = inspector.create(context, inputs);
         }
         if let Some(ref mut inspector) = self.tracing {
@@ -266,6 +359,10 @@ where
         if let Some(ref mut inspector) = self.tracing {
             inspector.create_end(context, inputs, outcome);
         }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
+            inspector.create_end(context, inputs, outcome);
+        }
     }
 
     #[inline]
@@ -275,6 +372,10 @@ where
         }
         if let Some(ref mut inspector) = self.tracing {
             <TracingInspector as Inspector<CTX>>::selfdestruct(inspector, contract, target, value);
+        }
+        #[cfg(feature = "js-tracer")]
+        for inspector in &mut self.js {
+            <JsInspector as Inspector<CTX>>::selfdestruct(inspector, contract, target, value);
         }
     }
 
@@ -324,4 +425,20 @@ pub enum Error {
     /// Error when deserializing the config
     #[error("error deserializing config: {0}")]
     InvalidConfig(#[from] serde_json::Error),
+    /// Error from a JS tracer
+    #[cfg(feature = "js-tracer")]
+    #[error(transparent)]
+    Js(#[from] crate::tracing::js::JsInspectorError),
+}
+
+/// Error type for [`MuxInspector::try_into_mux_frame_with_js`]
+#[cfg(feature = "js-tracer")]
+#[derive(Debug, Error)]
+pub enum MuxJsFrameError<E> {
+    /// Database error while building the builtin tracer frames
+    #[error("database error: {0}")]
+    Database(E),
+    /// Error while resolving a JS tracer result
+    #[error(transparent)]
+    Js(#[from] crate::tracing::js::JsInspectorError),
 }

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -19,6 +19,8 @@ use revm::{
     state::AccountInfo,
     Context, InspectEvm, MainBuilder, MainContext,
 };
+#[cfg(not(feature = "js-tracer"))]
+use revm_inspectors::tracing::MuxError;
 use revm_inspectors::tracing::{
     DebugInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
 };
@@ -1182,4 +1184,17 @@ fn test_geth_calltracer_logs_delegatecall() {
         Some(implementation),
         "Log emitter must NOT be the implementation (bytecode) address"
     );
+}
+
+#[cfg(not(feature = "js-tracer"))]
+#[test]
+fn test_geth_mux_tracer_rejects_js_tracer_without_feature() {
+    // Without the js-tracer feature, a mux config containing a JS tracer key must keep
+    // returning a clean error instead of panicking. This pins the pre-existing contract.
+    let config =
+        MuxConfig(HashMap::from_iter([(GethDebugTracerType::JsTracer("{}".to_string()), None)]));
+    assert!(matches!(
+        MuxInspector::try_from_config(config),
+        Err(MuxError::UnsupportedTracerType(GethDebugTracerType::JsTracer(_)))
+    ));
 }

--- a/tests/it/geth_js.rs
+++ b/tests/it/geth_js.rs
@@ -1,7 +1,12 @@
 //! Geth Js tracer tests
 
-use crate::utils::deploy_contract;
-use alloy_primitives::{address, hex, Address};
+use crate::utils::{deploy_contract, EvmDb};
+use alloy_primitives::{address, hex, map::HashMap, Address};
+use alloy_rpc_types_eth::TransactionInfo;
+use alloy_rpc_types_trace::geth::{
+    mux::MuxConfig, CallConfig, GethDebugBuiltInTracerType, GethDebugTracerConfig,
+    GethDebugTracerType, GethDebugTracingOptions, GethTrace,
+};
 use revm::{
     context::TxEnv,
     context_interface::{ContextTr, TransactTo},
@@ -11,7 +16,7 @@ use revm::{
     primitives::hardfork::SpecId,
     Context, InspectEvm, MainBuilder, MainContext,
 };
-use revm_inspectors::tracing::js::JsInspector;
+use revm_inspectors::tracing::{js::JsInspector, DebugInspector, MuxInspector, TransactionContext};
 use serde_json::json;
 
 #[test]
@@ -175,4 +180,142 @@ fn test_geth_jstracer_proxy_contract() {
     let (context, insp) = evm.ctx_inspector();
     let result = insp.json_result(res, context.tx(), context.block(), context.db_ref()).unwrap();
     assert_eq!(result, json!([{"event": "Transfer", "token": proxy_addr, "caller": deployer}]));
+}
+
+/// Deploys the `Foo` contract from `test_geth_jstracer_revert` and returns the EVM and the
+/// deployed address.
+fn deploy_foo() -> (EvmDb<CacheDB<EmptyDB>, ()>, Address) {
+    let code = hex!("608060405261023e806100115f395ff3fe608060405234801561000f575f80fd5b5060043610610034575f3560e01c8063c298557814610038578063febb0f7e14610042575b5f80fd5b61004061004c565b005b61004a61009c565b005b3373ffffffffffffffffffffffffffffffffffffffff167ff950957d2407bed19dc99b718b46b4ce6090c05589006dfb86fd22c34865b23e5f6040516100929190610177565b60405180910390a2565b3373ffffffffffffffffffffffffffffffffffffffff167ff950957d2407bed19dc99b718b46b4ce6090c05589006dfb86fd22c34865b23e5f6040516100e29190610177565b60405180910390a25f61012a576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401610121906101ea565b60405180910390fd5b565b5f819050919050565b5f819050919050565b5f819050919050565b5f61016161015c6101578461012c565b61013e565b610135565b9050919050565b61017181610147565b82525050565b5f60208201905061018a5f830184610168565b92915050565b5f82825260208201905092915050565b7f62617262617262617200000000000000000000000000000000000000000000005f82015250565b5f6101d4600983610190565b91506101df826101a0565b602082019050919050565b5f6020820190508181035f830152610201816101c8565b905091905056fea2646970667358221220e058dc2c4bd629d62405850cc8e08e6bfad0eea187260784445dfe8f3ee0bea564736f6c634300081a0033");
+    let mut evm = Context::mainnet()
+        .with_db(CacheDB::new(EmptyDB::default()))
+        .modify_cfg_chained(|cfg| cfg.spec = SpecId::CANCUN)
+        .build_mainnet();
+    let addr = deploy_contract(&mut evm, code.into(), Address::ZERO, SpecId::CANCUN)
+        .created_address()
+        .unwrap();
+    (evm, addr)
+}
+
+#[test]
+fn test_geth_mux_tracer_with_js_tracer() {
+    // A mux config mixing a builtin tracer and a JS tracer must be accepted and produce
+    // both results in the frame, like geth does. Uses the same `Foo` contract and JS
+    // tracer as `test_geth_jstracer_revert`.
+    let (evm, addr) = deploy_foo();
+
+    let js_code = r#"
+{
+    fault: function() {},
+    result: function(ctx) { return { error: !!ctx.error }; },
+}"#;
+
+    let call_config = CallConfig { only_top_call: Some(false), with_log: Some(true) };
+    let config = MuxConfig(HashMap::from_iter([
+        (
+            GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer),
+            Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
+        ),
+        (GethDebugTracerType::JsTracer(js_code.to_string()), None),
+    ]));
+
+    let insp =
+        MuxInspector::try_from_config(config).expect("mux config with a JS tracer key is valid");
+
+    let mut evm = evm.with_inspector(insp);
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller: Address::ZERO,
+            gas_limit: 1000000,
+            kind: TransactTo::Call(addr),
+            data: hex!("c2985578").into(), // call foo
+            nonce: 1,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success());
+
+    let (context, insp) = evm.ctx_inspector();
+    let frame = insp
+        .try_into_mux_frame_with_js(
+            &res,
+            context.tx(),
+            context.block(),
+            context.db_ref(),
+            TransactionInfo::default(),
+            TransactionContext::default(),
+        )
+        .unwrap();
+
+    assert_eq!(frame.0.len(), 2);
+
+    match frame.0.get(&GethDebugTracerType::JsTracer(js_code.to_string())) {
+        Some(GethTrace::JS(value)) => assert_eq!(value, &json!({"error": false})),
+        other => panic!("unexpected JS tracer entry: {other:?}"),
+    }
+
+    match frame.0.get(&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer)) {
+        Some(GethTrace::CallTracer(call_frame)) => {
+            assert!(call_frame.error.is_none());
+            assert_eq!(call_frame.logs.len(), 1);
+        }
+        other => panic!("unexpected call tracer entry: {other:?}"),
+    }
+}
+
+#[test]
+fn test_debug_inspector_mux_tracer_with_js_tracer() {
+    // End-to-end coverage of the path reth uses: a muxTracer debug request whose config
+    // contains a JS tracer, through DebugInspector::new, try_clone and get_result.
+    let (evm, addr) = deploy_foo();
+
+    let js_code = r#"
+{
+    fault: function() {},
+    result: function(ctx) { return { error: !!ctx.error }; },
+}"#;
+
+    let call_config = CallConfig { only_top_call: Some(false), with_log: Some(true) };
+    let config = MuxConfig(HashMap::from_iter([
+        (
+            GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::CallTracer),
+            Some(GethDebugTracerConfig(serde_json::to_value(call_config).unwrap())),
+        ),
+        (GethDebugTracerType::JsTracer(js_code.to_string()), None),
+    ]));
+
+    let opts = GethDebugTracingOptions {
+        tracer: Some(GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::MuxTracer)),
+        tracer_config: GethDebugTracerConfig(serde_json::to_value(&config).unwrap()),
+        ..Default::default()
+    };
+
+    let inspector = DebugInspector::new(opts).unwrap();
+    // exercise the fallible clone path with a JS tracer configured
+    let mut inspector = inspector.try_clone().unwrap();
+
+    let mut evm = evm.with_inspector(&mut inspector);
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller: Address::ZERO,
+            gas_limit: 1000000,
+            kind: TransactTo::Call(addr),
+            data: hex!("c2985578").into(), // call foo
+            nonce: 1,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success());
+
+    let (ctx, inspector) = evm.ctx_inspector();
+    let tx_env = ctx.tx().clone();
+    let block_env = ctx.block().clone();
+    let trace = inspector.get_result(None, &tx_env, &block_env, &res, ctx.db_mut()).unwrap();
+
+    match trace {
+        GethTrace::MuxTracer(frame) => {
+            assert_eq!(frame.0.len(), 2);
+            assert!(frame.0.contains_key(&GethDebugTracerType::JsTracer(js_code.to_string())));
+        }
+        other => panic!("unexpected trace: {other:?}"),
+    }
 }


### PR DESCRIPTION
Closes #58

Picks up where #291 left off (thanks @kustrun); that PR went stale before the alloy side was ready. The blocker is gone since alloy-rs/alloy#2442: `MuxConfig` and `MuxFrame` are keyed by `GethDebugTracerType`, so JS tracer keys can be expressed, and this crate already depends on alloy-rpc-types-trace 2.0.

## What

- `MuxInspector::try_from_config` accepts `GethDebugTracerType::JsTracer` keys behind the `js-tracer` feature: one `JsInspector` per key, dispatched from the inspector hooks next to the builtin inspectors.
- `try_into_mux_frame_with_js` resolves the JS tracers into the `MuxFrame`, keyed by their original code, matching geth's muxTracer output. The existing `try_into_mux_frame` signature is untouched.
- `DebugInspector` uses it for the MuxTracer variant, so `debug_traceTransaction` with a muxTracer config containing JS tracers now works end to end.
- Without the feature, per the review note on #291 ("keep mux support without the js feature"), the mux compiles as before and JS keys keep returning `UnsupportedTracerType`. A test pins that contract, and the feature-powerset job covers both sides (including `js-tracer` without `std`).

JS errors are propagated (`MuxJsFrameError`), not swallowed, consistent with how `DebugInspector` handles the standalone JS tracer.

## Breaking change

`MuxInspector` loses its `Clone` derive: `JsInspector` cannot be cloned (boa context), only re-created from its code. A fallible `try_clone()` replaces it, and `DebugInspector::try_clone` uses it. If you would rather keep `Clone` when the feature is off, happy to adjust.

## Tests

- `test_geth_mux_tracer_with_js_tracer`: callTracer and a JS tracer in one mux config, asserts both frame entries. On main this fails with `UnsupportedTracerType(JsTracer(..))`.
- `test_debug_inspector_mux_tracer_with_js_tracer`: the end-to-end path reth uses, through `DebugInspector::new`, `try_clone` and `get_result`.
- `test_geth_mux_tracer_rejects_js_tracer_without_feature` (compiled without `js-tracer`): pins the existing error contract.
