### PR TITLE
fix: pin time for boa engine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 # js-tracer
 boa_engine = { version = "0.21", optional = true }
 boa_gc = { version = "0.21", optional = true }
+# Work around time 0.3.48's conflicting conversion impls exposed through boa_engine.
+# See https://github.com/time-rs/time/issues/783.
+time = { version = "=0.3.47", optional = true, default-features = false }
 
 [dev-dependencies]
 alloy-hardforks = "0.4"
@@ -71,4 +74,4 @@ std = [
     "thiserror/std",
 ]
 serde = ["dep:serde", "revm/serde"]
-js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+js-tracer = ["dep:boa_engine", "dep:boa_gc", "dep:time"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,9 @@
 
 extern crate alloc;
 
+#[cfg(feature = "js-tracer")]
+use time as _;
+
 /// An inspector implementation for an EIP2930 Accesslist
 pub mod access_list;
 


### PR DESCRIPTION
Pins the `time` dependency used by the `js-tracer` feature to `=0.3.47` so Cargo does not resolve `time 0.3.48` through `boa_engine`.

`time 0.3.48` currently exposes conflicting conversion impls that make `boa_engine 0.21.1` fail to compile under CI; see https://github.com/time-rs/time/issues/783. The crate-root import keeps the direct dependency visible to `unused_crate_dependencies`.