### PR TITLE
chore: integrate revm glam-devnet-6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,10 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 # js-tracer
 boa_engine = { version = "0.21", optional = true }
 boa_gc = { version = "0.21", optional = true }
-# Work around time 0.3.48's conflicting conversion impls exposed through boa_engine.
-# See https://github.com/time-rs/time/issues/783.
-time = { version = "=0.3.47", optional = true, default-features = false }
+# time 0.3.48's conflicting conversion impls (https://github.com/time-rs/time/issues/783)
+# are resolved as of 0.3.51, so the previous `=0.3.47` pin is relaxed to stay
+# compatible with downstream consumers (e.g. reth's vergen requiring time >=0.3.51).
+time = { version = "0.3", optional = true, default-features = false }
 
 [dev-dependencies]
 alloy-hardforks = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,17 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc", "dep:time"]
+
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,15 +78,15 @@ serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc", "dep:time"]
 
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "35d8fb4f97f90d7232964d3bc9a70c607a1d7f50" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "b55020b237400aa42ce48fcaefdf5cdc255b5558" }


### PR DESCRIPTION
Patch revm to the `glam-devnet-6` branch (`35d8fb4f`).

Also relaxes the `time` pin (`=0.3.47` → `0.3`): the time#783 boa conflict is resolved as of 0.3.51, and the pin blocked downstream consumers (reth's vergen requires `time >=0.3.51`). boa_engine 0.21.1 + js-tracer verified compiling on 0.3.51.