### PR TITLE
feat(writer): render named-but-undecoded logs with raw topics/data

### DIFF
--- a/src/tracing/writer.rs
+++ b/src/tracing/writer.rs
@@ -322,37 +322,56 @@ impl<W: Write> TraceWriter<W> {
         let log_style = self.log_style();
         self.write_branch()?;
 
-        if let Some(name) = log.decoded_name() {
-            write!(self.writer, "emit {name}({log_style}")?;
-            if let Some(params) = log.decoded_params() {
+        match (log.decoded_name(), log.decoded_params()) {
+            // Fully decoded event: `emit Name(param: value, ...)`.
+            (Some(name), Some(params)) => {
+                write!(self.writer, "emit {name}({log_style}")?;
                 for (i, (param_name, value)) in params.iter().enumerate() {
                     if i > 0 {
                         self.writer.write_all(b", ")?;
                     }
                     write!(self.writer, "{param_name}: {value}")?;
                 }
+                writeln!(self.writer, "{log_style:#})")?;
             }
-            writeln!(self.writer, "{log_style:#})")?;
-        } else {
-            for (i, topic) in log.raw_log.topics().iter().enumerate() {
-                if i == 0 {
-                    self.writer.write_all(b" emit topic 0")?;
-                } else {
-                    self.write_pipes()?;
-                    write!(self.writer, "       topic {i}")?;
-                }
-                writeln!(self.writer, ": {log_style}{topic}{log_style:#}")?;
+            // `topic0` matched a known event but the data is not ABI-decodable: surface the
+            // event name and still show the raw topics/data instead of dropping either half.
+            (Some(name), None) => {
+                writeln!(self.writer, "emit {name}")?;
+                self.write_raw_log(log, "       ")?;
             }
-
-            if !log.raw_log.topics().is_empty() {
-                self.write_pipes()?;
+            // Unknown event: raw topics/data only.
+            (None, _) => {
+                self.write_raw_log(log, " emit ")?;
             }
-            writeln!(
-                self.writer,
-                "          data: {log_style}{data}{log_style:#}",
-                data = log.raw_log.data
-            )?;
         }
+
+        Ok(())
+    }
+
+    /// Writes the raw topics and data of a `log`. `first_prefix` is printed inline before
+    /// `topic 0`, so the caller controls the first line: `" emit "` for a fully undecoded log,
+    /// or padding when an `emit Name` header line has already been written.
+    fn write_raw_log(&mut self, log: &CallLog, first_prefix: &str) -> io::Result<()> {
+        let log_style = self.log_style();
+        for (i, topic) in log.raw_log.topics().iter().enumerate() {
+            if i == 0 {
+                write!(self.writer, "{first_prefix}topic 0")?;
+            } else {
+                self.write_pipes()?;
+                write!(self.writer, "       topic {i}")?;
+            }
+            writeln!(self.writer, ": {log_style}{topic}{log_style:#}")?;
+        }
+
+        if !log.raw_log.topics().is_empty() {
+            self.write_pipes()?;
+        }
+        writeln!(
+            self.writer,
+            "          data: {log_style}{data}{log_style:#}",
+            data = log.raw_log.data
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
## Motivation

When an event is emitted with data that is not ABI-encoded, its `topic0` can still match a known event while `decode_log` fails. Foundry's decoder then produces `DecodedCallLog { name: Some(event_name), params: None }` (foundry-rs/foundry#15087, for foundry-rs/foundry#10451).

`TraceWriter::write_log` branched only on `decoded_name()`, so that case rendered `emit Exchange()` and never reached the raw topics/data branch: the raw data was dropped. On its own the decoder change trades "raw data, no name" for "name, no data".

## Change

Match on `(decoded_name(), decoded_params())`:
- `(Some, Some)`: decoded render, unchanged
- `(Some, None)`: print the event name, then the raw topics/data (new)
- `(None, _)`: raw render, unchanged

The raw topics/data block moves into a small `write_raw_log` helper shared by the named-but-undecoded and fully-undecoded paths. Rendering follows the named header plus raw topics/data layout.

## Notes

Existing writer snapshots exercise `(Some, Some)` and `(None, _)`; the Counter events carry indexed topics, so `params` is always set and the new arm is not hit by them. `cargo test --all-features` passes unchanged. Happy to add a dedicated snapshot for the `(Some, None)` case if you would prefer one in this PR.
