### PR TITLE
fix(geth): derive log positions from trace ordering

### DIFF
--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -646,11 +646,7 @@ where
             let log_count = self.log_count();
             let trace = self.last_trace();
             trace.ordering.push(TraceMemberOrder::Log(trace.logs.len()));
-            trace.logs.push(
-                CallLog::from(log)
-                    .with_position(trace.children.len() as u64)
-                    .with_index(log_count as u64),
-            );
+            trace.logs.push(CallLog::from(log).with_index(log_count as u64));
         }
     }
 

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -189,7 +189,7 @@ pub struct CallLog {
     pub decoded: Option<Box<DecodedCallLog>>,
     /// The position of the log relative to subcalls within the same trace.
     pub position: u64,
-    /// The position of the log relative to subcalls within the same trace.
+    /// The index of the log in the transaction trace.
     pub index: u64,
 }
 
@@ -388,6 +388,35 @@ impl CallTraceNode {
         })
     }
 
+    /// Converts recorded logs into geth log frames.
+    ///
+    /// `CallLogFrame::position` is relative to child calls in the same frame, so derive it from
+    /// the recorded member ordering instead of persisting it while tracing.
+    fn geth_call_log_frames(&self) -> Vec<CallLogFrame> {
+        let mut log_positions = self.logs.iter().map(|log| log.position).collect::<Vec<_>>();
+        let mut call_position = 0;
+
+        for item in &self.ordering {
+            match *item {
+                TraceMemberOrder::Call(_) => call_position += 1,
+                TraceMemberOrder::Log(log_idx) => log_positions[log_idx] = call_position,
+                TraceMemberOrder::Step(_) => {}
+            }
+        }
+
+        self.logs
+            .iter()
+            .zip(log_positions)
+            .map(|(log, position)| CallLogFrame {
+                address: Some(log.address),
+                topics: Some(log.raw_log.topics().to_vec()),
+                data: Some(log.raw_log.data.clone()),
+                position: Some(position),
+                index: Some(log.index),
+            })
+            .collect()
+    }
+
     /// If the trace is a selfdestruct, returns the `TransactionTrace` for a parity trace.
     pub fn parity_selfdestruct_trace(&self, trace_address: Vec<usize>) -> Option<TransactionTrace> {
         let trace = self.parity_selfdestruct_action()?;
@@ -470,17 +499,7 @@ impl CallTraceNode {
         }
 
         if include_logs && !self.logs.is_empty() {
-            call_frame.logs = self
-                .logs
-                .iter()
-                .map(|log| CallLogFrame {
-                    address: Some(log.address),
-                    topics: Some(log.raw_log.topics().to_vec()),
-                    data: Some(log.raw_log.data.clone()),
-                    position: Some(log.position),
-                    index: Some(log.index),
-                })
-                .collect();
+            call_frame.logs = self.geth_call_log_frames();
         }
 
         call_frame

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -1,6 +1,6 @@
 //! Geth tests
 use crate::utils::deploy_contract;
-use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256, U256};
+use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, LogData, TxKind, B256, U256};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     erc7562::Erc7562Config, mux::MuxConfig, CallConfig, FlatCallConfig, GethDebugBuiltInTracerType,
@@ -20,8 +20,49 @@ use revm::{
     Context, InspectEvm, MainBuilder, MainContext,
 };
 use revm_inspectors::tracing::{
+    types::{CallLog, CallTraceNode, TraceMemberOrder},
     DebugInspector, MuxInspector, TracingInspector, TracingInspectorConfig,
 };
+
+#[test]
+fn test_geth_calltracer_log_positions_are_derived_from_ordering() {
+    fn call_log(index: u64) -> CallLog {
+        CallLog {
+            address: Address::ZERO,
+            raw_log: LogData::default(),
+            decoded: None,
+            // Use a stale value to ensure geth output derives position from node ordering.
+            position: 99,
+            index,
+        }
+    }
+
+    let node = CallTraceNode {
+        children: vec![1, 2],
+        logs: vec![call_log(0), call_log(1), call_log(2), call_log(3)],
+        ordering: vec![
+            TraceMemberOrder::Log(0),
+            TraceMemberOrder::Call(0),
+            TraceMemberOrder::Log(1),
+            TraceMemberOrder::Log(2),
+            TraceMemberOrder::Call(1),
+            TraceMemberOrder::Log(3),
+        ],
+        ..Default::default()
+    };
+
+    let frame = node.geth_empty_call_frame(true);
+
+    assert_eq!(frame.logs.len(), 4);
+    assert_eq!(
+        frame.logs.iter().map(|log| log.position).collect::<Vec<_>>(),
+        vec![Some(0), Some(1), Some(1), Some(2)]
+    );
+    assert_eq!(
+        frame.logs.iter().map(|log| log.index).collect::<Vec<_>>(),
+        vec![Some(0), Some(1), Some(2), Some(3)]
+    );
+}
 
 #[test]
 fn test_geth_calltracer_logs() {


### PR DESCRIPTION
Closes #187.

## Summary

- Derive geth `CallLogFrame.position` from `CallTraceNode::ordering` when building call frames.
- Stop writing the position into `CallLog` during tracing.
- Keep the existing `CallLog::position` field as a compatibility fallback instead of removing public API.
- Add a regression test for interleaved log/call ordering.

## Rationale

`CallLogFrame.position` is relative to child calls in the same frame. The trace node already records the order of calls and logs, so the geth output can compute the position at serialization time without adding recursion to the call-frame builder.

The patch intentionally leaves the existing non-recursive call-frame rollup unchanged.

## Tests

- `cargo test test_geth_calltracer_log_positions_are_derived_from_ordering`
- `cargo test --test it geth::`
- `cargo test`
- `cargo fmt --check` (passes; stable rustfmt prints warnings for nightly-only config options)
