### PR TITLE
feat: add top-of-stack snapshot type

### DIFF
--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -384,7 +384,8 @@ impl TracingInspectorConfig {
     }
 }
 
-/// How much of the stack to record. Nothing, just the items pushed, or the full stack
+/// How much of the stack to record. Nothing, just the items pushed, the full stack, or only the
+/// top item
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum StackSnapshotType {
     /// Don't record stack snapshots
@@ -396,6 +397,8 @@ pub enum StackSnapshotType {
     Pushes,
     /// Record the full stack
     Full,
+    /// Record only the top item of the stack
+    Top,
 }
 
 impl StackSnapshotType {
@@ -415,6 +418,12 @@ impl StackSnapshotType {
     #[inline]
     pub const fn is_pushes(self) -> bool {
         matches!(self, Self::Pushes)
+    }
+
+    /// Returns true if this is the [StackSnapshotType::Top] variant
+    #[inline]
+    pub const fn is_top(self) -> bool {
+        matches!(self, Self::Top)
     }
 }
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -456,6 +456,9 @@ impl TracingInspector {
             || self.config.record_stack_snapshots.is_full()
         {
             Some(interp.stack.data().as_slice().into())
+        } else if self.config.record_stack_snapshots.is_top() {
+            let top = interp.stack.data().last().map(core::slice::from_ref).unwrap_or_default();
+            Some(top.into())
         } else {
             None
         };

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -12,6 +12,8 @@ mod geth;
 mod geth_js;
 #[cfg(feature = "std")]
 mod parity;
+#[cfg(feature = "std")]
+mod stack;
 #[cfg(feature = "js-tracer")]
 mod test_native_bigint;
 #[cfg(feature = "std")]

--- a/tests/it/stack.rs
+++ b/tests/it/stack.rs
@@ -1,0 +1,64 @@
+//! Stack snapshot tests
+
+use crate::utils::inspect_deploy_contract;
+use alloy_primitives::{hex, Address, U256};
+use revm::{
+    database::CacheDB, database_interface::EmptyDB, primitives::hardfork::SpecId, Context,
+    MainBuilder, MainContext,
+};
+use revm_inspectors::tracing::{StackSnapshotType, TracingInspector, TracingInspectorConfig};
+
+/// Runs `PUSH1 1; PUSH1 2; PUSH1 3; STOP` as create init code and returns the recorded stack
+/// snapshot of each step.
+fn stack_snapshots(snapshot_type: StackSnapshotType) -> Vec<Option<Box<[U256]>>> {
+    let mut insp = TracingInspector::new(
+        TracingInspectorConfig::none().set_steps(true).set_stack_snapshots(snapshot_type),
+    );
+
+    let mut evm = Context::mainnet()
+        .with_db(CacheDB::new(EmptyDB::default()))
+        .build_mainnet()
+        .with_inspector(&mut insp);
+
+    let res = inspect_deploy_contract(
+        &mut evm,
+        hex!("60016002600300").into(),
+        Address::ZERO,
+        SpecId::CANCUN,
+    );
+    assert!(res.is_success());
+
+    let nodes = insp.traces().nodes();
+    assert_eq!(nodes.len(), 1);
+
+    nodes[0].trace.steps.iter().map(|step| step.stack.clone()).collect()
+}
+
+#[test]
+fn test_top_stack_snapshots() {
+    let snapshots = stack_snapshots(StackSnapshotType::Top);
+
+    assert_eq!(
+        snapshots,
+        vec![
+            // The stack is recorded before each step executes.
+            Some(Box::default()),
+            Some(Box::from([U256::from(1)])),
+            Some(Box::from([U256::from(2)])),
+            Some(Box::from([U256::from(3)])),
+        ]
+    );
+}
+
+#[test]
+fn test_top_stack_snapshots_match_the_top_of_full_snapshots() {
+    let full = stack_snapshots(StackSnapshotType::Full);
+    let top = stack_snapshots(StackSnapshotType::Top);
+
+    assert_eq!(full.len(), top.len());
+    for (full, top) in full.iter().zip(top) {
+        let full_top: &[U256] =
+            full.as_ref().unwrap().last().map(core::slice::from_ref).unwrap_or_default();
+        assert_eq!(top.as_deref(), Some(full_top));
+    }
+}


### PR DESCRIPTION
> **Blocked until the next minor release.** Adding a public `StackSnapshotType` variant can break downstream exhaustive matches. Hold merging until the next minor release.

Adds StackSnapshotType::Top, which records only the top item of the stack before each step executes, writing a single-element (or empty) snapshot into CallTraceStep::stack.

This fills the gap between None and Full for consumers that only need the current top of the stack per step: Full clones the entire stack (up to 1024 words) on every step, while Top copies one word. Consumers reading step.stack.last() work unchanged.
