### PR TITLE
fix: render named-but-undecoded logs with their raw topics and data

### DIFF
--- a/src/tracing/writer.rs
+++ b/src/tracing/writer.rs
@@ -322,37 +322,45 @@ impl<W: Write> TraceWriter<W> {
         let log_style = self.log_style();
         self.write_branch()?;
 
-        if let Some(name) = log.decoded_name() {
+        let name = log.decoded_name();
+
+        // A known event with decoded params renders as `emit Name(p: v, ...)`.
+        if let (Some(name), Some(params)) = (name, log.decoded_params()) {
             write!(self.writer, "emit {name}({log_style}")?;
-            if let Some(params) = log.decoded_params() {
-                for (i, (param_name, value)) in params.iter().enumerate() {
-                    if i > 0 {
-                        self.writer.write_all(b", ")?;
-                    }
-                    write!(self.writer, "{param_name}: {value}")?;
+            for (i, (param_name, value)) in params.iter().enumerate() {
+                if i > 0 {
+                    self.writer.write_all(b", ")?;
                 }
+                write!(self.writer, "{param_name}: {value}")?;
             }
             writeln!(self.writer, "{log_style:#})")?;
-        } else {
-            for (i, topic) in log.raw_log.topics().iter().enumerate() {
-                if i == 0 {
-                    self.writer.write_all(b" emit topic 0")?;
-                } else {
-                    self.write_pipes()?;
-                    write!(self.writer, "       topic {i}")?;
-                }
-                writeln!(self.writer, ": {log_style}{topic}{log_style:#}")?;
-            }
-
-            if !log.raw_log.topics().is_empty() {
-                self.write_pipes()?;
-            }
-            writeln!(
-                self.writer,
-                "          data: {log_style}{data}{log_style:#}",
-                data = log.raw_log.data
-            )?;
+            return Ok(());
         }
+
+        // Otherwise show the raw topics and data. When the event name is known but its data could
+        // not be decoded (for example non-ABI-encoded data emitted via inline assembly), keep the
+        // name so it is not lost; unknown events keep `emit topic 0` on the branch line.
+        if let Some(name) = name {
+            writeln!(self.writer, "emit {name}")?;
+        }
+        for (i, topic) in log.raw_log.topics().iter().enumerate() {
+            if i == 0 && name.is_none() {
+                self.writer.write_all(b" emit topic 0")?;
+            } else {
+                self.write_pipes()?;
+                write!(self.writer, "       topic {i}")?;
+            }
+            writeln!(self.writer, ": {log_style}{topic}{log_style:#}")?;
+        }
+
+        if !log.raw_log.topics().is_empty() {
+            self.write_pipes()?;
+        }
+        writeln!(
+            self.writer,
+            "          data: {log_style}{data}{log_style:#}",
+            data = log.raw_log.data
+        )?;
 
         Ok(())
     }

--- a/tests/it/writer.rs
+++ b/tests/it/writer.rs
@@ -402,3 +402,55 @@ fn test_fallback_short_calldata() {
         "Short calldata call should NOT show 'receive' in trace, got:\n{trace_output}"
     );
 }
+
+/// A log whose event name is known but whose data could not be decoded (for example non-ABI
+/// data emitted via inline assembly, see https://github.com/foundry-rs/foundry/issues/10451) must
+/// still show the event name AND the raw topics and data, not an empty `Name()`.
+#[test]
+fn test_named_but_undecoded_log_keeps_name_and_raw_data() {
+    use alloy_primitives::LogData;
+    use revm_inspectors::tracing::types::{CallLog, DecodedCallLog, TraceMemberOrder};
+
+    // Run a trivial call to obtain a trace node to attach the log to.
+    let initcode = bytes!("6001600c60003960016000f300"); // deploy STOP
+    let mut evm = Context::mainnet()
+        .with_db(CacheDB::new(EmptyDB::default()))
+        .build_mainnet_with_inspector(TracingInspector::new(TracingInspectorConfig::all()));
+    let address = inspect_deploy_contract(&mut evm, initcode, Address::default(), SpecId::CANCUN)
+        .created_address()
+        .unwrap();
+
+    evm.set_inspector(TracingInspector::new(TracingInspectorConfig::all()));
+    evm.inspect_tx_commit(
+        TxEnv::builder()
+            .data(bytes!("ab"))
+            .kind(TransactTo::Call(address))
+            .gas_priority_fee(None)
+            .nonce(1)
+            .build_fill(),
+    )
+    .unwrap();
+
+    // Simulate a decoder that matched topic0 to a known event but could not decode its data.
+    let topic = b256!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    let tracer = evm.inspector();
+    let node = tracer.traces_mut().nodes_mut().first_mut().expect("one trace node");
+    let log_index = node.logs.len();
+    node.logs.push(CallLog {
+        address: Address::default(),
+        raw_log: LogData::new_unchecked(vec![topic], bytes!("deadbeef")),
+        decoded: Some(Box::new(DecodedCallLog {
+            name: Some("Exchange".to_string()),
+            params: None,
+        })),
+        position: 0,
+        index: 0,
+    });
+    node.ordering.push(TraceMemberOrder::Log(log_index));
+
+    let out = write_traces(tracer);
+    assert!(out.contains("emit Exchange"), "event name must be shown, got:\n{out}");
+    assert!(out.contains("topic 0"), "raw topic must be shown, got:\n{out}");
+    assert!(out.contains("deadbeef"), "raw data must be shown, got:\n{out}");
+    assert!(!out.contains("Exchange()"), "must not render empty parens, got:\n{out}");
+}


### PR DESCRIPTION
## Motivation

When a log matches a known event signature by `topic0` but its data cannot be ABI-decoded (for example non-ABI-encoded data emitted via inline assembly, foundry-rs/foundry#10451), the decoded log has a `name` but no `params`. The trace writer branched only on the presence of a name, so it rendered `emit Name()` with empty parentheses and dropped the raw topics and data, losing the information the raw fallback would otherwise have shown.

## Solution

When the event name is known but there are no decoded params, render the name followed by the raw topics and data:

```
├─ emit Exchange
│        topic 0: 0x...
│           data: 0x...
```

Fully decoded logs (`emit Name(param: value, ...)`) and unknown events (`emit topic 0: ...` on the branch line) are unchanged.

Added `test_named_but_undecoded_log_keeps_name_and_raw_data`. `cargo test --workspace` and `cargo test --workspace --all-features` pass, and the existing `test_trace_printing` snapshots are unchanged.

This is the writer half of foundry-rs/foundry#10451; the decoder half that surfaces the matched name is foundry-rs/foundry#15087. The layout follows the existing raw-log style and can be adjusted to maintainer preference.
