### PR TITLE
feat: glamsterdam-devnet-7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,15 +73,15 @@ std = [
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,15 +73,15 @@ std = [
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 [patch.crates-io]
-revm = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-context = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-database = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-handler = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
-revm-state = { git = "https://github.com/bluealloy/revm", rev = "30e04db0a6285a79f613dc404bfc04e4b757b0c9" }
+revm = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "335a35ddb370b667bff248109524a4efc589213f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,16 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }


### PR DESCRIPTION
Glamsterdam devnet-7 integration.

Patches revm to `glam-devnet-7` tip (bluealloy/revm#3795, rev `0c688c68`). No code changes needed.

Devnet branch — not for merge into main.