### PR TITLE
chore: bump revm to 42.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "42.0.0", default-features = false }
+revm = { version = "42.0.1", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "41.0.0", default-features = false }
+revm = { version = "42.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
Bumps `revm` to `42.0.1` (revm [v115](https://github.com/bluealloy/revm/releases/tag/v115), a patch release on top of [v114](https://github.com/bluealloy/revm/releases/tag/v114)).

No source changes were required; the workspace builds, clippy is clean and all 100 tests pass.