### PR TITLE
fix(tracing): add defaults to trace literals

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -134,12 +134,14 @@ impl<'a> GethTraceBuilder<'a> {
         let mut storage = HashMap::default();
         self.fill_geth_trace(main_trace_node, &opts, &mut storage, &mut struct_logs);
 
+        #[allow(clippy::needless_update)]
         DefaultFrame {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
             gas: receipt_gas_used,
             return_value,
             struct_logs,
+            ..Default::default()
         }
     }
 

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -705,6 +705,7 @@ impl CallTraceStep {
         opts: &GethDefaultTracingOptions,
         depth: u64,
     ) -> StructLog {
+        #[allow(clippy::needless_update)]
         StructLog {
             depth,
             error: self.as_error(),
@@ -731,6 +732,7 @@ impl CallTraceStep {
 
             // This is always `None` in the RPC response.
             memory_size: None,
+            ..Default::default()
         }
     }
 


### PR DESCRIPTION
## Summary

- add `..Default::default()` to the `DefaultFrame` and `StructLog` literals
- allow `clippy::needless_update` while the upstream Alloy fields are pending

This keeps `revm-inspectors` source-compatible with the EIP-8037 RPC field additions in [alloy-rs/alloy#4113](https://github.com/alloy-rs/alloy/pull/4113).

Tests: `cargo test`; `cargo +nightly clippy --all-targets --all-features -- -D warnings`

Prompted by: @mattsse