### PR TITLE
feat(tracing): support EIP-8037 trace fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,7 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+
+[patch.crates-io]
+# Temporary dependency patch for the pending EIP-8037 RPC types.
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "bfd6f67cd4b96a207797d9520a5ee592518e9828" }

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -20,7 +20,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use revm::{
     bytecode::opcode,
-    context_interface::result::{HaltReasonTr, ResultAndState},
+    context_interface::result::{HaltReasonTr, ResultAndState, ResultGas},
     primitives::KECCAK_EMPTY,
     state::{AccountInfo, EvmState},
     DatabaseRef,
@@ -123,6 +123,20 @@ impl<'a> GethTraceBuilder<'a> {
         return_value: Bytes,
         opts: GethDefaultTracingOptions,
     ) -> DefaultFrame {
+        self.geth_traces_with_result_gas(
+            ResultGas::default().with_total_gas_spent(receipt_gas_used),
+            return_value,
+            opts,
+        )
+    }
+
+    /// Generate a geth-style trace with EIP-8037 transaction gas accounting.
+    pub fn geth_traces_with_result_gas(
+        &self,
+        gas: ResultGas,
+        return_value: Bytes,
+        opts: GethDefaultTracingOptions,
+    ) -> DefaultFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -138,7 +152,11 @@ impl<'a> GethTraceBuilder<'a> {
         DefaultFrame {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
-            gas: receipt_gas_used,
+            gas: gas.tx_gas_used(),
+            regular_gas_used: (gas.state_gas_spent_final() > 0)
+                .then_some(gas.block_regular_gas_used()),
+            state_gas_used: (gas.state_gas_spent_final() > 0).then_some(gas.block_state_gas_used()),
+            gas_refund: (gas.state_gas_spent_final() > 0).then_some(gas.final_refunded()),
             return_value,
             struct_logs,
             ..Default::default()
@@ -153,6 +171,14 @@ impl<'a> GethTraceBuilder<'a> {
     /// [revm::context::result::ExecutionResult] of the executed
     /// transaction.
     pub fn geth_call_traces(&self, opts: CallConfig, gas_used: u64) -> CallFrame {
+        self.geth_call_traces_with_result_gas(
+            opts,
+            ResultGas::default().with_total_gas_spent(gas_used),
+        )
+    }
+
+    /// Generate a geth-style call trace with EIP-8037 transaction gas accounting.
+    pub fn geth_call_traces_with_result_gas(&self, opts: CallConfig, gas: ResultGas) -> CallFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -161,7 +187,12 @@ impl<'a> GethTraceBuilder<'a> {
         // first fill up the root
         let main_trace_node = &self.nodes[0];
         let mut root_call_frame = main_trace_node.geth_empty_call_frame(include_logs);
-        root_call_frame.gas_used = U256::from(gas_used);
+        root_call_frame.gas_used = U256::from(gas.tx_gas_used());
+        if gas.state_gas_spent_final() > 0 {
+            root_call_frame.regular_gas_used = Some(U256::from(gas.block_regular_gas_used()));
+            root_call_frame.state_gas_used = Some(U256::from(gas.block_state_gas_used()));
+            root_call_frame.gas_refund = Some(U256::from(gas.final_refunded()));
+        }
 
         // selfdestructs are not recorded as individual call traces but are derived from
         // the call trace and are added as additional `CallFrame` objects to the parent call

--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -40,6 +40,8 @@ pub enum DebugInspector {
     PreStateTracer(TracingInspector, PreStateConfig),
     /// Noop tracer
     Noop(revm::inspector::NoOpInspector),
+    /// EIP-8037 state-gas tracer
+    StateGasTracer(revm::inspector::NoOpInspector),
     /// Mux tracer
     Mux(MuxInspector, MuxConfig),
     /// FlatCallTracer
@@ -63,6 +65,7 @@ impl DebugInspector {
                 Self::PreStateTracer(inspector.clone(), *config)
             }
             Self::Noop(inspector) => Self::Noop(*inspector),
+            Self::StateGasTracer(inspector) => Self::StateGasTracer(*inspector),
             Self::Mux(inspector, config) => Self::Mux(inspector.clone(), config.clone()),
             Self::FlatCallTracer(inspector) => Self::FlatCallTracer(inspector.clone()),
             Self::Erc7562Tracer(inspector, config) => {
@@ -111,6 +114,9 @@ impl DebugInspector {
                     }
                     GethDebugBuiltInTracerType::NoopTracer => {
                         Self::Noop(revm::inspector::NoOpInspector)
+                    }
+                    GethDebugBuiltInTracerType::StateGasTracer => {
+                        Self::StateGasTracer(revm::inspector::NoOpInspector)
                     }
                     GethDebugBuiltInTracerType::MuxTracer => {
                         let config = tracer_config
@@ -187,7 +193,7 @@ impl DebugInspector {
             | Self::FlatCallTracer(inspector)
             | Self::Erc7562Tracer(inspector, _)
             | Self::Default(inspector, _) => inspector.fuse(),
-            Self::Noop(_) => {}
+            Self::Noop(_) | Self::StateGasTracer(_) => {}
             Self::Mux(inspector, config) => {
                 *inspector = MuxInspector::try_from_config(config.clone())?;
             }
@@ -224,7 +230,10 @@ impl DebugInspector {
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
                 inspector.set_transaction_caller(tx_env.caller());
-                inspector.geth_builder().geth_call_traces(*config, res.result.tx_gas_used()).into()
+                inspector
+                    .geth_builder()
+                    .geth_call_traces_with_result_gas(*config, *res.result.gas())
+                    .into()
             }
             Self::PreStateTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
@@ -235,6 +244,13 @@ impl DebugInspector {
                     .into()
             }
             Self::Noop(_) => NoopFrame::default().into(),
+            Self::StateGasTracer(_) => alloy_rpc_types_trace::geth::StateGasTrace {
+                gas_used: res.result.gas().tx_gas_used(),
+                regular_gas_used: res.result.gas().block_regular_gas_used(),
+                state_gas_used: res.result.gas().block_state_gas_used(),
+                gas_refund: res.result.gas().final_refunded(),
+            }
+            .into(),
             Self::Mux(inspector, _) => inspector
                 .try_into_mux_frame(res, db, tx_info)
                 .map_err(DebugInspectorError::Database)?
@@ -261,8 +277,8 @@ impl DebugInspector {
                 inspector.set_transaction_caller(tx_env.caller());
                 inspector
                     .geth_builder()
-                    .geth_traces(
-                        res.result.tx_gas_used(),
+                    .geth_traces_with_result_gas(
+                        *res.result.gas(),
                         res.result.output().unwrap_or_default().clone(),
                         *config,
                     )
@@ -293,6 +309,7 @@ macro_rules! delegate {
             Self::Erc7562Tracer($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
             Self::Default($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
             Self::Noop($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::StateGasTracer($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
             Self::Mux($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
             #[cfg(feature = "js-tracer")]
             Self::Js($insp) => Inspector::<CTX>::$method($insp, $($arg),*),

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -21,7 +21,7 @@ use revm::{
         CallInput, CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, Interpreter,
         InterpreterResult,
     },
-    primitives::{hardfork::SpecId, Address, Bytes, Log, B256, U256},
+    primitives::{hardfork::SpecId, Address, Bytes, Log, B256, I256, U256},
     Inspector, JournalEntry,
 };
 
@@ -494,6 +494,12 @@ impl TracingInspector {
             gas_refund_counter: interp.gas.refunded() as u64,
             gas_used,
             immediate_bytes,
+            state_gas_cost: None,
+            state_gas_reservoir: (interp.gas.reservoir() > 0
+                || interp.gas.state_gas_spent() != 0
+                || interp.gas.state_gas_spilled() != 0)
+                .then_some(interp.gas.reservoir()),
+            state_gas_spent: interp.gas.state_gas_spent(),
 
             // These fields will be populated in `step_end`.
             push_stack: None,
@@ -591,6 +597,10 @@ impl TracingInspector {
         // step the remaining gas here, at the end of the step.
         // TODO: Figure out why this can overflow. https://github.com/paradigmxyz/revm-inspectors/pull/38
         step.gas_cost = step.gas_remaining.saturating_sub(interp.gas.remaining());
+        let state_gas_delta = interp.gas.state_gas_spent().saturating_sub(step.state_gas_spent);
+        if state_gas_delta != 0 {
+            step.state_gas_cost = Some(I256::try_from(state_gas_delta).unwrap());
+        }
 
         // set the status
         step.status = interp.bytecode.action().as_ref().and_then(|i| i.instruction_result())

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -9,7 +9,7 @@ use alloc::{
     vec::Vec,
 };
 pub use alloy_primitives::Log;
-use alloy_primitives::{Address, Bytes, FixedBytes, LogData, U256};
+use alloy_primitives::{Address, Bytes, FixedBytes, LogData, I256, U256};
 use alloy_rpc_types_trace::{
     geth::{CallFrame, CallLogFrame, GethDefaultTracingOptions, StructLog},
     parity::{
@@ -430,6 +430,7 @@ impl CallTraceNode {
 
     /// Converts this call trace into an _empty_ geth [CallFrame]
     pub fn geth_empty_call_frame(&self, include_logs: bool) -> CallFrame {
+        #[allow(clippy::needless_update)]
         let mut call_frame = CallFrame {
             typ: self.trace.kind.to_string(),
             from: self.trace.caller,
@@ -443,6 +444,7 @@ impl CallTraceNode {
             revert_reason: None,
             calls: Default::default(),
             logs: Default::default(),
+            ..Default::default()
         };
 
         if self.trace.kind.is_static_call() {
@@ -684,6 +686,12 @@ pub struct CallTraceStep {
     // Fields filled in `step_end`
     /// Gas cost of step execution
     pub gas_cost: u64,
+    /// Net state-gas change caused by this step.
+    pub state_gas_cost: Option<I256>,
+    /// State-gas reservoir before this step.
+    pub state_gas_reservoir: Option<u64>,
+    /// State-gas spent before this step, used to calculate `state_gas_cost`.
+    pub state_gas_spent: i64,
     /// Change of the contract state after step execution (effect of the SLOAD/SSTORE instructions)
     pub storage_change: Option<Box<StorageChange>>,
     /// Final status of the step
@@ -711,6 +719,8 @@ impl CallTraceStep {
             error: self.as_error(),
             gas: self.gas_remaining,
             gas_cost: self.gas_cost,
+            state_gas_cost: self.state_gas_cost,
+            state_gas_reservoir: self.state_gas_reservoir,
             op: if self.op.is_valid() { self.op.as_str().into() } else { "Unknown".into() },
             pc: self.pc as u64,
             refund_counter: Some(self.gas_refund_counter),

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -156,6 +156,41 @@ fn test_geth_erc7562_tracer() {
 }
 
 #[test]
+fn test_geth_state_gas_tracer() {
+    let caller = address!("1000000000000000000000000000000000000002");
+    let context = Context::mainnet().with_db(CacheDB::<EmptyDB>::default());
+    let mut inspector = DebugInspector::new(GethDebugTracingOptions::state_gas_tracer()).unwrap();
+    let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 1000000,
+            kind: TransactTo::Call(Address::ZERO),
+            data: Bytes::default(),
+            nonce: 0,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "{res:#?}");
+
+    let (ctx, inspector) = evm.ctx_inspector();
+    let tx_env = ctx.tx().clone();
+    let block_env = ctx.block().clone();
+    let trace = inspector.get_result(None, &tx_env, &block_env, &res, ctx.db_mut()).unwrap();
+
+    match trace {
+        GethTrace::StateGasTracer(frame) => {
+            assert_eq!(frame.gas_used, res.result.gas().tx_gas_used());
+            assert_eq!(frame.regular_gas_used, res.result.gas().block_regular_gas_used());
+            assert_eq!(frame.state_gas_used, res.result.gas().block_state_gas_used());
+            assert_eq!(frame.gas_refund, res.result.gas().final_refunded());
+        }
+        _ => panic!("Expected StateGasTracer"),
+    }
+}
+
+#[test]
 fn test_geth_mux_tracer() {
     /*
     contract LogTracing {


### PR DESCRIPTION
Implements the EIP-8037 tracing additions from [ethereum/execution-apis#852](https://github.com/ethereum/execution-apis/pull/852), using [Alloy #4113](https://github.com/alloy-rs/alloy/pull/4113) as a temporary dependency patch.

Changes:
- expose regular/state gas accounting on default and call traces;
- emit per-opcode `stateGasCost` and `stateGasReservoir` values;
- support the `stateGasTracer` built-in tracer;
- add an integration test for the new tracer.

The Alloy patch is intentionally pinned by commit and can be removed once #4113 is merged. The additive RPC fields preserve backwards-compatible decoding for existing callers.

Tests: `cargo test`
Clippy: `cargo +nightly clippy --all-targets --all-features -- -D warnings`

Prompted by: @mattsse