### PR TITLE
feat(tracing): support EIP-8037 trace fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,3 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
-
-[patch.crates-io]
-# Temporary dependency patch for the pending EIP-8037 RPC types.
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "cf5166faffd795e9a35d3497447799d1b4bd1566" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,4 +75,4 @@ js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
 # Temporary dependency patch for the pending EIP-8037 RPC types.
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "8c1630dfe56b55214d210726da9562faafc475af" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "cf5166faffd795e9a35d3497447799d1b4bd1566" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,4 +75,4 @@ js-tracer = ["dep:boa_engine", "dep:boa_gc"]
 
 [patch.crates-io]
 # Temporary dependency patch for the pending EIP-8037 RPC types.
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "bfd6f67cd4b96a207797d9520a5ee592518e9828" }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "8c1630dfe56b55214d210726da9562faafc475af" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,7 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+
+[patch.crates-io]
+# Temporary dependency patch for the pending EIP-8037 RPC types.
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy", rev = "bfd6f67cd4b96a207797d9520a5ee592518e9828" }

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -173,7 +173,7 @@ impl<'a> GethTraceBuilder<'a> {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
             gas: receipt_gas_used,
-            regular_gas_used: gas.map(|gas| gas.block_regular_gas_used()),
+            execution_gas_used: gas.map(|gas| gas.block_regular_gas_used()),
             state_gas_used: gas.map(|gas| gas.block_state_gas_used()),
             gas_refund: gas.map(|gas| gas.final_refunded()),
             return_value,
@@ -214,7 +214,7 @@ impl<'a> GethTraceBuilder<'a> {
         let mut root_call_frame = main_trace_node.geth_empty_call_frame(include_logs);
         root_call_frame.gas_used = U256::from(gas_used);
         if let Some(gas) = gas.filter(|_| self.is_eip8037_enabled()) {
-            root_call_frame.regular_gas_used = Some(U256::from(gas.block_regular_gas_used()));
+            root_call_frame.execution_gas_used = Some(U256::from(gas.block_regular_gas_used()));
             root_call_frame.state_gas_used = Some(U256::from(gas.block_state_gas_used()));
             root_call_frame.gas_refund = Some(U256::from(gas.final_refunded()));
         }

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -20,7 +20,7 @@ use alloy_rpc_types_trace::geth::{
 };
 use revm::{
     bytecode::opcode,
-    context_interface::result::{HaltReasonTr, ResultAndState},
+    context_interface::result::{HaltReasonTr, ResultAndState, ResultGas},
     primitives::KECCAK_EMPTY,
     state::{AccountInfo, EvmState},
     DatabaseRef,
@@ -123,6 +123,20 @@ impl<'a> GethTraceBuilder<'a> {
         return_value: Bytes,
         opts: GethDefaultTracingOptions,
     ) -> DefaultFrame {
+        self.geth_traces_with_result_gas(
+            ResultGas::default().with_total_gas_spent(receipt_gas_used),
+            return_value,
+            opts,
+        )
+    }
+
+    /// Generate a geth-style trace with EIP-8037 transaction gas accounting.
+    pub fn geth_traces_with_result_gas(
+        &self,
+        gas: ResultGas,
+        return_value: Bytes,
+        opts: GethDefaultTracingOptions,
+    ) -> DefaultFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -138,7 +152,11 @@ impl<'a> GethTraceBuilder<'a> {
         DefaultFrame {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
-            gas: receipt_gas_used,
+            gas: gas.tx_gas_used(),
+            regular_gas_used: (gas.state_gas_spent_final() > 0)
+                .then_some(gas.block_regular_gas_used()),
+            state_gas_used: (gas.state_gas_spent_final() > 0).then_some(gas.block_state_gas_used()),
+            gas_refund: (gas.state_gas_spent_final() > 0).then_some(gas.final_refunded()),
             return_value,
             struct_logs,
             ..Default::default()
@@ -153,6 +171,14 @@ impl<'a> GethTraceBuilder<'a> {
     /// [revm::context::result::ExecutionResult] of the executed
     /// transaction.
     pub fn geth_call_traces(&self, opts: CallConfig, gas_used: u64) -> CallFrame {
+        self.geth_call_traces_with_result_gas(
+            opts,
+            ResultGas::default().with_total_gas_spent(gas_used),
+        )
+    }
+
+    /// Generate a geth-style call trace with EIP-8037 transaction gas accounting.
+    pub fn geth_call_traces_with_result_gas(&self, opts: CallConfig, gas: ResultGas) -> CallFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -161,7 +187,12 @@ impl<'a> GethTraceBuilder<'a> {
         // first fill up the root
         let main_trace_node = &self.nodes[0];
         let mut root_call_frame = main_trace_node.geth_empty_call_frame(include_logs);
-        root_call_frame.gas_used = U256::from(gas_used);
+        root_call_frame.gas_used = U256::from(gas.tx_gas_used());
+        if gas.state_gas_spent_final() > 0 {
+            root_call_frame.regular_gas_used = Some(U256::from(gas.block_regular_gas_used()));
+            root_call_frame.state_gas_used = Some(U256::from(gas.block_state_gas_used()));
+            root_call_frame.gas_refund = Some(U256::from(gas.final_refunded()));
+        }
 
         // selfdestructs are not recorded as individual call traces but are derived from
         // the call trace and are added as additional `CallFrame` objects to the parent call

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -21,7 +21,7 @@ use alloy_rpc_types_trace::geth::{
 use revm::{
     bytecode::opcode,
     context_interface::result::{HaltReasonTr, ResultAndState, ResultGas},
-    primitives::KECCAK_EMPTY,
+    primitives::{hardfork::SpecId, KECCAK_EMPTY},
     state::{AccountInfo, EvmState},
     DatabaseRef,
 };
@@ -31,19 +31,27 @@ use revm::{
 pub struct GethTraceBuilder<'a> {
     /// Recorded trace nodes.
     nodes: Cow<'a, [CallTraceNode]>,
+    /// EVM specification used to produce the trace.
+    spec_id: Option<SpecId>,
 }
 
 impl GethTraceBuilder<'static> {
     /// Returns a new instance of the builder from [`Cow::Owned`]
     pub fn new(nodes: Vec<CallTraceNode>) -> GethTraceBuilder<'static> {
-        Self { nodes: Cow::Owned(nodes) }
+        Self { nodes: Cow::Owned(nodes), spec_id: None }
     }
 }
 
 impl<'a> GethTraceBuilder<'a> {
     /// Returns a new instance of the builder from [`Cow::Borrowed`]
     pub fn new_borrowed(nodes: &'a [CallTraceNode]) -> GethTraceBuilder<'a> {
-        Self { nodes: Cow::Borrowed(nodes) }
+        Self { nodes: Cow::Borrowed(nodes), spec_id: None }
+    }
+
+    /// Sets the EVM specification used to produce the trace.
+    pub fn with_spec_id(mut self, spec_id: SpecId) -> Self {
+        self.spec_id = Some(spec_id);
+        self
     }
 
     /// Consumes the builder and returns the recorded trace nodes.
@@ -54,6 +62,10 @@ impl<'a> GethTraceBuilder<'a> {
     /// Returns the sum of all steps in the recorded node traces.
     fn trace_step_count(&self) -> usize {
         self.nodes.iter().map(|node| node.trace.steps.len()).sum()
+    }
+
+    fn is_eip8037_enabled(&self) -> bool {
+        self.spec_id.is_some_and(|spec| SpecId::is_enabled_in(spec, SpecId::AMSTERDAM))
     }
 
     /// Fill in the geth trace with all steps of the trace and its children traces in the order they
@@ -123,17 +135,23 @@ impl<'a> GethTraceBuilder<'a> {
         return_value: Bytes,
         opts: GethDefaultTracingOptions,
     ) -> DefaultFrame {
-        self.geth_traces_with_result_gas(
-            ResultGas::default().with_total_gas_spent(receipt_gas_used),
-            return_value,
-            opts,
-        )
+        self.geth_traces_inner(receipt_gas_used, None, return_value, opts)
     }
 
     /// Generate a geth-style trace with EIP-8037 transaction gas accounting.
     pub fn geth_traces_with_result_gas(
         &self,
         gas: ResultGas,
+        return_value: Bytes,
+        opts: GethDefaultTracingOptions,
+    ) -> DefaultFrame {
+        self.geth_traces_inner(gas.tx_gas_used(), Some(gas), return_value, opts)
+    }
+
+    fn geth_traces_inner(
+        &self,
+        receipt_gas_used: u64,
+        gas: Option<ResultGas>,
         return_value: Bytes,
         opts: GethDefaultTracingOptions,
     ) -> DefaultFrame {
@@ -148,15 +166,16 @@ impl<'a> GethTraceBuilder<'a> {
         let mut storage = HashMap::default();
         self.fill_geth_trace(main_trace_node, &opts, &mut storage, &mut struct_logs);
 
+        let gas = gas.filter(|_| self.is_eip8037_enabled());
+
         #[allow(clippy::needless_update)]
         DefaultFrame {
             // If the top-level trace succeeded, then it was a success
             failed: !main_trace.success,
-            gas: gas.tx_gas_used(),
-            regular_gas_used: (gas.state_gas_spent_final() > 0)
-                .then_some(gas.block_regular_gas_used()),
-            state_gas_used: (gas.state_gas_spent_final() > 0).then_some(gas.block_state_gas_used()),
-            gas_refund: (gas.state_gas_spent_final() > 0).then_some(gas.final_refunded()),
+            gas: receipt_gas_used,
+            regular_gas_used: gas.map(|gas| gas.block_regular_gas_used()),
+            state_gas_used: gas.map(|gas| gas.block_state_gas_used()),
+            gas_refund: gas.map(|gas| gas.final_refunded()),
             return_value,
             struct_logs,
             ..Default::default()
@@ -171,14 +190,20 @@ impl<'a> GethTraceBuilder<'a> {
     /// [revm::context::result::ExecutionResult] of the executed
     /// transaction.
     pub fn geth_call_traces(&self, opts: CallConfig, gas_used: u64) -> CallFrame {
-        self.geth_call_traces_with_result_gas(
-            opts,
-            ResultGas::default().with_total_gas_spent(gas_used),
-        )
+        self.geth_call_traces_inner(opts, gas_used, None)
     }
 
     /// Generate a geth-style call trace with EIP-8037 transaction gas accounting.
     pub fn geth_call_traces_with_result_gas(&self, opts: CallConfig, gas: ResultGas) -> CallFrame {
+        self.geth_call_traces_inner(opts, gas.tx_gas_used(), Some(gas))
+    }
+
+    fn geth_call_traces_inner(
+        &self,
+        opts: CallConfig,
+        gas_used: u64,
+        gas: Option<ResultGas>,
+    ) -> CallFrame {
         if self.nodes.is_empty() {
             return Default::default();
         }
@@ -187,8 +212,8 @@ impl<'a> GethTraceBuilder<'a> {
         // first fill up the root
         let main_trace_node = &self.nodes[0];
         let mut root_call_frame = main_trace_node.geth_empty_call_frame(include_logs);
-        root_call_frame.gas_used = U256::from(gas.tx_gas_used());
-        if gas.state_gas_spent_final() > 0 {
+        root_call_frame.gas_used = U256::from(gas_used);
+        if let Some(gas) = gas.filter(|_| self.is_eip8037_enabled()) {
             root_call_frame.regular_gas_used = Some(U256::from(gas.block_regular_gas_used()));
             root_call_frame.state_gas_used = Some(U256::from(gas.block_state_gas_used()));
             root_call_frame.gas_refund = Some(U256::from(gas.final_refunded()));

--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -246,7 +246,7 @@ impl DebugInspector {
             Self::Noop(_) => NoopFrame::default().into(),
             Self::StateGasTracer(_) => alloy_rpc_types_trace::geth::StateGasTrace {
                 gas_used: res.result.gas().tx_gas_used(),
-                regular_gas_used: res.result.gas().block_regular_gas_used(),
+                execution_gas_used: res.result.gas().block_regular_gas_used(),
                 state_gas_used: res.result.gas().block_state_gas_used(),
                 gas_refund: res.result.gas().final_refunded(),
             }

--- a/src/tracing/debug.rs
+++ b/src/tracing/debug.rs
@@ -40,6 +40,8 @@ pub enum DebugInspector {
     PreStateTracer(TracingInspector, PreStateConfig),
     /// Noop tracer
     Noop(revm::inspector::NoOpInspector),
+    /// EIP-8037 state-gas tracer
+    StateGasTracer(revm::inspector::NoOpInspector),
     /// Mux tracer
     Mux(MuxInspector, MuxConfig),
     /// FlatCallTracer
@@ -63,6 +65,7 @@ impl DebugInspector {
                 Self::PreStateTracer(inspector.clone(), *config)
             }
             Self::Noop(inspector) => Self::Noop(*inspector),
+            Self::StateGasTracer(inspector) => Self::StateGasTracer(*inspector),
             Self::Mux(inspector, config) => Self::Mux(inspector.clone(), config.clone()),
             Self::FlatCallTracer(inspector) => Self::FlatCallTracer(inspector.clone()),
             Self::Erc7562Tracer(inspector, config) => {
@@ -111,6 +114,9 @@ impl DebugInspector {
                     }
                     GethDebugBuiltInTracerType::NoopTracer => {
                         Self::Noop(revm::inspector::NoOpInspector)
+                    }
+                    GethDebugBuiltInTracerType::StateGasTracer => {
+                        Self::StateGasTracer(revm::inspector::NoOpInspector)
                     }
                     GethDebugBuiltInTracerType::MuxTracer => {
                         let config = tracer_config
@@ -187,7 +193,7 @@ impl DebugInspector {
             | Self::FlatCallTracer(inspector)
             | Self::Erc7562Tracer(inspector, _)
             | Self::Default(inspector, _) => inspector.fuse(),
-            Self::Noop(_) => {}
+            Self::Noop(_) | Self::StateGasTracer(_) => {}
             Self::Mux(inspector, config) => {
                 *inspector = MuxInspector::try_from_config(config.clone())?;
             }
@@ -224,7 +230,10 @@ impl DebugInspector {
             Self::CallTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
                 inspector.set_transaction_caller(tx_env.caller());
-                inspector.geth_builder().geth_call_traces(*config, res.result.tx_gas_used()).into()
+                inspector
+                    .geth_builder()
+                    .geth_call_traces_with_result_gas(*config, *res.result.gas())
+                    .into()
             }
             Self::PreStateTracer(inspector, config) => {
                 inspector.set_transaction_gas_limit(tx_env.gas_limit());
@@ -235,6 +244,13 @@ impl DebugInspector {
                     .into()
             }
             Self::Noop(_) => NoopFrame::default().into(),
+            Self::StateGasTracer(_) => alloy_rpc_types_trace::geth::StateGasTrace {
+                gas_used: res.result.gas().tx_gas_used(),
+                regular_gas_used: res.result.gas().block_regular_gas_used(),
+                state_gas_used: res.result.gas().block_state_gas_used(),
+                gas_refund: res.result.gas().final_refunded(),
+            }
+            .into(),
             Self::Mux(inspector, _) => inspector
                 .try_into_mux_frame(res, db, tx_info)
                 .map_err(DebugInspectorError::Database)?
@@ -261,8 +277,8 @@ impl DebugInspector {
                 inspector.set_transaction_caller(tx_env.caller());
                 inspector
                     .geth_builder()
-                    .geth_traces(
-                        res.result.tx_gas_used(),
+                    .geth_traces_with_result_gas(
+                        *res.result.gas(),
                         res.result.output().unwrap_or_default().clone(),
                         *config,
                     )
@@ -293,6 +309,7 @@ macro_rules! delegate {
             Self::Erc7562Tracer($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
             Self::Default($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
             Self::Noop($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
+            Self::StateGasTracer($insp) => Inspector::<CTX>::$method($insp, $($arg),*),
             Self::Mux($insp, _) => Inspector::<CTX>::$method($insp, $($arg),*),
             #[cfg(feature = "js-tracer")]
             Self::Js($insp) => Inspector::<CTX>::$method($insp, $($arg),*),

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -14,14 +14,14 @@ use core::{borrow::Borrow, mem};
 use revm::{
     bytecode::opcode::{self, OpCode},
     context::{JournalTr, LocalContextTr},
-    context_interface::ContextTr,
+    context_interface::{Cfg, ContextTr},
     inspector::JournalExt,
     interpreter::{
         interpreter_types::{Immediates, Jumps, LoopControl, ReturnData, RuntimeFlag},
         CallInput, CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, Interpreter,
         InterpreterResult,
     },
-    primitives::{hardfork::SpecId, Address, Bytes, Log, B256, I256, U256},
+    primitives::{hardfork::SpecId, Address, Bytes, Log, B256, U256},
     Inspector, JournalEntry,
 };
 
@@ -250,7 +250,11 @@ impl TracingInspector {
     /// Consumes the Inspector and returns a [GethTraceBuilder].
     #[inline]
     pub fn into_geth_builder(self) -> GethTraceBuilder<'static> {
-        GethTraceBuilder::new(self.traces.arena)
+        let builder = GethTraceBuilder::new(self.traces.arena);
+        match self.spec_id {
+            Some(spec_id) => builder.with_spec_id(spec_id),
+            None => builder,
+        }
     }
 
     /// Returns the  [GethTraceBuilder] for the recorded traces without consuming the type.
@@ -260,7 +264,11 @@ impl TracingInspector {
     /// starting a new transaction: [`Self::fuse`]
     #[inline]
     pub fn geth_builder(&self) -> GethTraceBuilder<'_> {
-        GethTraceBuilder::new_borrowed(&self.traces.arena)
+        let builder = GethTraceBuilder::new_borrowed(&self.traces.arena);
+        match self.spec_id {
+            Some(spec_id) => builder.with_spec_id(spec_id),
+            None => builder,
+        }
     }
 
     /// Returns true if we're no longer in the context of the root call.
@@ -495,10 +503,11 @@ impl TracingInspector {
             gas_used,
             immediate_bytes,
             state_gas_cost: None,
-            state_gas_reservoir: (interp.gas.reservoir() > 0
-                || interp.gas.state_gas_spent() != 0
-                || interp.gas.state_gas_spilled() != 0)
-                .then_some(interp.gas.reservoir()),
+            state_gas_reservoir: SpecId::is_enabled_in(
+                interp.runtime_flag.spec_id(),
+                SpecId::AMSTERDAM,
+            )
+            .then_some(interp.gas.reservoir()),
             state_gas_spent: interp.gas.state_gas_spent(),
 
             // These fields will be populated in `step_end`.
@@ -598,8 +607,8 @@ impl TracingInspector {
         // TODO: Figure out why this can overflow. https://github.com/paradigmxyz/revm-inspectors/pull/38
         step.gas_cost = step.gas_remaining.saturating_sub(interp.gas.remaining());
         let state_gas_delta = interp.gas.state_gas_spent().saturating_sub(step.state_gas_spent);
-        if state_gas_delta != 0 {
-            step.state_gas_cost = Some(I256::try_from(state_gas_delta).unwrap());
+        if step.state_gas_reservoir.is_some() && state_gas_delta != 0 {
+            step.state_gas_cost = Some(state_gas_delta);
         }
 
         // set the status
@@ -611,6 +620,10 @@ impl<CTX> Inspector<CTX> for TracingInspector
 where
     CTX: ContextTr<Journal: JournalExt>,
 {
+    fn initialize_interp(&mut self, interp: &mut Interpreter, _context: &mut CTX) {
+        self.spec_id = Some(interp.runtime_flag.spec_id());
+    }
+
     #[inline]
     fn step(&mut self, interp: &mut Interpreter, context: &mut CTX) {
         if self.config.record_steps {
@@ -640,6 +653,8 @@ where
     }
 
     fn call(&mut self, context: &mut CTX, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        self.spec_id = Some(context.cfg().spec().into());
+
         // determine correct `from` and `to` based on the call scheme
         let (from, to) = match inputs.scheme {
             CallScheme::DelegateCall | CallScheme::CallCode => {
@@ -685,6 +700,8 @@ where
     }
 
     fn create(&mut self, context: &mut CTX, inputs: &mut CreateInputs) -> Option<CreateOutcome> {
+        self.spec_id = Some(context.cfg().spec().into());
+
         let nonce = context.journal_mut().load_account(inputs.caller()).ok()?.info.nonce;
         self.start_trace_on_call(
             context,

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -21,7 +21,7 @@ use revm::{
         CallInput, CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome, Interpreter,
         InterpreterResult,
     },
-    primitives::{hardfork::SpecId, Address, Bytes, Log, B256, U256},
+    primitives::{hardfork::SpecId, Address, Bytes, Log, B256, I256, U256},
     Inspector, JournalEntry,
 };
 
@@ -494,6 +494,12 @@ impl TracingInspector {
             gas_refund_counter: interp.gas.refunded() as u64,
             gas_used,
             immediate_bytes,
+            state_gas_cost: None,
+            state_gas_reservoir: (interp.gas.reservoir() > 0
+                || interp.gas.state_gas_spent() != 0
+                || interp.gas.state_gas_spilled() != 0)
+                .then_some(interp.gas.reservoir()),
+            state_gas_spent: interp.gas.state_gas_spent(),
 
             // These fields will be populated in `step_end`.
             push_stack: None,
@@ -591,6 +597,10 @@ impl TracingInspector {
         // step the remaining gas here, at the end of the step.
         // TODO: Figure out why this can overflow. https://github.com/paradigmxyz/revm-inspectors/pull/38
         step.gas_cost = step.gas_remaining.saturating_sub(interp.gas.remaining());
+        let state_gas_delta = interp.gas.state_gas_spent().saturating_sub(step.state_gas_spent);
+        if state_gas_delta != 0 {
+            step.state_gas_cost = Some(I256::try_from(state_gas_delta).unwrap());
+        }
 
         // set the status
         step.status = interp.bytecode.action().as_ref().and_then(|i| i.instruction_result())

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -5,7 +5,7 @@ use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     mux::{MuxConfig, MuxFrame},
     CallConfig, FlatCallConfig, FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
-    NoopFrame, PreStateConfig,
+    NoopFrame, PreStateConfig, StateGasTrace,
 };
 use revm::{
     context_interface::{
@@ -36,6 +36,7 @@ enum TraceConfig {
     Call(CallConfig),
     PreState(PreStateConfig),
     FlatCall(FlatCallConfig),
+    StateGas,
     Noop,
 }
 
@@ -83,6 +84,12 @@ impl MuxInspector {
                     }
                     configs.push((builtin, TraceConfig::Noop));
                 }
+                GethDebugBuiltInTracerType::StateGasTracer => {
+                    if tracer_config.is_some() {
+                        return Err(Error::UnexpectedConfig(builtin));
+                    }
+                    configs.push((builtin, TraceConfig::StateGas));
+                }
                 GethDebugBuiltInTracerType::FlatCallTracer => {
                     let flatcall_config = tracer_config
                         .ok_or(Error::MissingConfig(builtin))?
@@ -122,7 +129,7 @@ impl MuxInspector {
                     if let Some(inspector) = &self.tracing {
                         inspector
                             .geth_builder()
-                            .geth_call_traces(*call_config, result.result.tx_gas_used())
+                            .geth_call_traces_with_result_gas(*call_config, *result.result.gas())
                             .into()
                     } else {
                         continue;
@@ -150,6 +157,13 @@ impl MuxInspector {
                     }
                 }
                 TraceConfig::Noop => NoopFrame::default().into(),
+                TraceConfig::StateGas => StateGasTrace {
+                    gas_used: result.result.gas().tx_gas_used(),
+                    regular_gas_used: result.result.gas().block_regular_gas_used(),
+                    state_gas_used: result.result.gas().block_state_gas_used(),
+                    gas_refund: result.result.gas().final_refunded(),
+                }
+                .into(),
             };
 
             frame.insert(GethDebugTracerType::BuiltInTracer(*tracer_type), trace);

--- a/src/tracing/mux.rs
+++ b/src/tracing/mux.rs
@@ -159,7 +159,7 @@ impl MuxInspector {
                 TraceConfig::Noop => NoopFrame::default().into(),
                 TraceConfig::StateGas => StateGasTrace {
                     gas_used: result.result.gas().tx_gas_used(),
-                    regular_gas_used: result.result.gas().block_regular_gas_used(),
+                    execution_gas_used: result.result.gas().block_regular_gas_used(),
                     state_gas_used: result.result.gas().block_state_gas_used(),
                     gas_refund: result.result.gas().final_refunded(),
                 }

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -9,7 +9,7 @@ use alloc::{
     vec::Vec,
 };
 pub use alloy_primitives::Log;
-use alloy_primitives::{Address, Bytes, FixedBytes, LogData, U256};
+use alloy_primitives::{Address, Bytes, FixedBytes, LogData, I256, U256};
 use alloy_rpc_types_trace::{
     geth::{CallFrame, CallLogFrame, GethDefaultTracingOptions, StructLog},
     parity::{
@@ -686,6 +686,12 @@ pub struct CallTraceStep {
     // Fields filled in `step_end`
     /// Gas cost of step execution
     pub gas_cost: u64,
+    /// Net state-gas change caused by this step.
+    pub state_gas_cost: Option<I256>,
+    /// State-gas reservoir before this step.
+    pub state_gas_reservoir: Option<u64>,
+    /// State-gas spent before this step, used to calculate `state_gas_cost`.
+    pub state_gas_spent: i64,
     /// Change of the contract state after step execution (effect of the SLOAD/SSTORE instructions)
     pub storage_change: Option<Box<StorageChange>>,
     /// Final status of the step
@@ -713,6 +719,8 @@ impl CallTraceStep {
             error: self.as_error(),
             gas: self.gas_remaining,
             gas_cost: self.gas_cost,
+            state_gas_cost: self.state_gas_cost,
+            state_gas_reservoir: self.state_gas_reservoir,
             op: if self.op.is_valid() { self.op.as_str().into() } else { "Unknown".into() },
             pc: self.pc as u64,
             refund_counter: Some(self.gas_refund_counter),

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -9,7 +9,7 @@ use alloc::{
     vec::Vec,
 };
 pub use alloy_primitives::Log;
-use alloy_primitives::{Address, Bytes, FixedBytes, LogData, I256, U256};
+use alloy_primitives::{Address, Bytes, FixedBytes, LogData, U256};
 use alloy_rpc_types_trace::{
     geth::{CallFrame, CallLogFrame, GethDefaultTracingOptions, StructLog},
     parity::{
@@ -687,10 +687,11 @@ pub struct CallTraceStep {
     /// Gas cost of step execution
     pub gas_cost: u64,
     /// Net state-gas change caused by this step.
-    pub state_gas_cost: Option<I256>,
+    pub state_gas_cost: Option<i64>,
     /// State-gas reservoir before this step.
     pub state_gas_reservoir: Option<u64>,
     /// State-gas spent before this step, used to calculate `state_gas_cost`.
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub state_gas_spent: i64,
     /// Change of the contract state after step execution (effect of the SLOAD/SSTORE instructions)
     pub storage_change: Option<Box<StorageChange>>,

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -205,7 +205,7 @@ fn test_geth_state_gas_tracer() {
     match trace {
         GethTrace::StateGasTracer(frame) => {
             assert_eq!(frame.gas_used, gas.tx_gas_used());
-            assert_eq!(frame.regular_gas_used, gas.block_regular_gas_used());
+            assert_eq!(frame.execution_gas_used, gas.block_regular_gas_used());
             assert_eq!(frame.state_gas_used, gas.block_state_gas_used());
             assert_eq!(frame.gas_refund, gas.final_refunded());
         }
@@ -227,7 +227,7 @@ fn test_geth_eip8037_fields_follow_fork() {
         let GethTrace::Default(frame) = trace else {
             panic!("Expected default tracer");
         };
-        assert_eq!(frame.regular_gas_used, enabled.then_some(gas.block_regular_gas_used()));
+        assert_eq!(frame.execution_gas_used, enabled.then_some(gas.block_regular_gas_used()));
         assert_eq!(frame.state_gas_used, enabled.then_some(0));
         assert_eq!(frame.gas_refund, enabled.then_some(gas.final_refunded()));
 
@@ -246,7 +246,7 @@ fn test_geth_eip8037_fields_follow_fork() {
         }
 
         let value = serde_json::to_value(&frame).unwrap();
-        assert_eq!(value.get("regularGasUsed").is_some(), enabled);
+        assert_eq!(value.get("executionGasUsed").is_some(), enabled);
         assert_eq!(value.get("stateGasUsed").is_some(), enabled);
         assert_eq!(value.get("gasRefund").is_some(), enabled);
         if enabled {
@@ -269,7 +269,7 @@ fn test_geth_eip8037_fields_follow_fork() {
             panic!("Expected call tracer");
         };
         assert_eq!(
-            frame.regular_gas_used,
+            frame.execution_gas_used,
             enabled.then(|| U256::from(call_gas.block_regular_gas_used()))
         );
         assert_eq!(frame.state_gas_used, enabled.then_some(U256::ZERO));
@@ -282,7 +282,7 @@ fn test_geth_eip8037_fields_follow_fork() {
         let GethTrace::Default(frame) = trace else {
             panic!("Expected default tracer");
         };
-        assert_eq!(frame.regular_gas_used, enabled.then_some(empty_gas.block_regular_gas_used()));
+        assert_eq!(frame.execution_gas_used, enabled.then_some(empty_gas.block_regular_gas_used()));
         assert_eq!(frame.state_gas_used, enabled.then_some(0));
         assert_eq!(frame.gas_refund, enabled.then_some(empty_gas.final_refunded()));
     }
@@ -454,7 +454,7 @@ fn test_geth_mux_tracer() {
     match state_gas_frame {
         GethTrace::StateGasTracer(state_gas) => {
             assert_eq!(state_gas.gas_used, res.result.gas().tx_gas_used());
-            assert_eq!(state_gas.regular_gas_used, res.result.gas().block_regular_gas_used());
+            assert_eq!(state_gas.execution_gas_used, res.result.gas().block_regular_gas_used());
             assert_eq!(state_gas.state_gas_used, res.result.gas().block_state_gas_used());
             assert_eq!(state_gas.gas_refund, res.result.gas().final_refunded());
         }

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -1,6 +1,6 @@
 //! Geth tests
 use crate::utils::deploy_contract;
-use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256};
+use alloy_primitives::{address, hex, map::HashMap, Address, Bytes, TxKind, B256, U256};
 use alloy_rpc_types_eth::TransactionInfo;
 use alloy_rpc_types_trace::geth::{
     erc7562::Erc7562Config, mux::MuxConfig, CallConfig, FlatCallConfig, GethDebugBuiltInTracerType,
@@ -10,7 +10,7 @@ use alloy_rpc_types_trace::geth::{
 use revm::{
     bytecode::{opcode, Bytecode},
     context::TxEnv,
-    context_interface::{ContextTr, TransactTo},
+    context_interface::{result::ResultGas, ContextTr, TransactTo},
     database::CacheDB,
     database_interface::EmptyDB,
     handler::EvmTr,
@@ -155,18 +155,31 @@ fn test_geth_erc7562_tracer() {
     }
 }
 
-#[test]
-fn test_geth_state_gas_tracer() {
+fn trace_contract(
+    spec: SpecId,
+    opts: GethDebugTracingOptions,
+    code: Bytes,
+) -> (GethTrace, ResultGas) {
+    let contract = address!("1000000000000000000000000000000000000001");
     let caller = address!("1000000000000000000000000000000000000002");
-    let context = Context::mainnet().with_db(CacheDB::<EmptyDB>::default());
-    let mut inspector = DebugInspector::new(GethDebugTracingOptions::state_gas_tracer()).unwrap();
+    let context = Context::mainnet()
+        .with_db(CacheDB::<EmptyDB>::default())
+        .modify_cfg_chained(|cfg| cfg.set_spec_and_mainnet_gas_params(spec))
+        .modify_db_chained(|db| {
+            db.insert_account_info(
+                contract,
+                AccountInfo { code: Some(Bytecode::new_raw(code)), ..Default::default() },
+            );
+        });
+    let mut inspector = DebugInspector::new(opts).unwrap();
     let mut evm = context.build_mainnet().with_inspector(&mut inspector);
 
     let res = evm
         .inspect_tx(TxEnv {
             caller,
-            gas_limit: 1000000,
-            kind: TransactTo::Call(Address::ZERO),
+            gas_limit: 1_000_000,
+            gas_price: 0,
+            kind: TransactTo::Call(contract),
             data: Bytes::default(),
             nonce: 0,
             ..Default::default()
@@ -178,15 +191,100 @@ fn test_geth_state_gas_tracer() {
     let tx_env = ctx.tx().clone();
     let block_env = ctx.block().clone();
     let trace = inspector.get_result(None, &tx_env, &block_env, &res, ctx.db_mut()).unwrap();
+    (trace, *res.result.gas())
+}
+
+#[test]
+fn test_geth_state_gas_tracer() {
+    // SSTORE slot 0 from zero to one, then STOP.
+    let code = hex!("600160005500").into();
+    let (trace, gas) =
+        trace_contract(SpecId::AMSTERDAM, GethDebugTracingOptions::state_gas_tracer(), code);
+    assert!(gas.block_state_gas_used() > 0);
 
     match trace {
         GethTrace::StateGasTracer(frame) => {
-            assert_eq!(frame.gas_used, res.result.gas().tx_gas_used());
-            assert_eq!(frame.regular_gas_used, res.result.gas().block_regular_gas_used());
-            assert_eq!(frame.state_gas_used, res.result.gas().block_state_gas_used());
-            assert_eq!(frame.gas_refund, res.result.gas().final_refunded());
+            assert_eq!(frame.gas_used, gas.tx_gas_used());
+            assert_eq!(frame.regular_gas_used, gas.block_regular_gas_used());
+            assert_eq!(frame.state_gas_used, gas.block_state_gas_used());
+            assert_eq!(frame.gas_refund, gas.final_refunded());
         }
         _ => panic!("Expected StateGasTracer"),
+    }
+}
+
+#[test]
+fn test_geth_eip8037_fields_follow_fork() {
+    // SSTORE slot 0 from zero to one and restore it to zero. This exercises both positive and
+    // negative per-opcode state-gas changes while leaving the transaction's final state gas at
+    // zero.
+    let code = hex!("6001600055600060005500");
+
+    for (spec, enabled) in [(SpecId::OSAKA, false), (SpecId::AMSTERDAM, true)] {
+        let (trace, gas) = trace_contract(spec, GethDebugTracingOptions::default(), code.into());
+        assert_eq!(gas.block_state_gas_used(), 0);
+
+        let GethTrace::Default(frame) = trace else {
+            panic!("Expected default tracer");
+        };
+        assert_eq!(frame.regular_gas_used, enabled.then_some(gas.block_regular_gas_used()));
+        assert_eq!(frame.state_gas_used, enabled.then_some(0));
+        assert_eq!(frame.gas_refund, enabled.then_some(gas.final_refunded()));
+
+        let sstores =
+            frame.struct_logs.iter().filter(|log| log.opcode() == "SSTORE").collect::<Vec<_>>();
+        assert_eq!(sstores.len(), 2);
+        if enabled {
+            assert!(sstores[0].state_gas_cost.is_some_and(|cost| cost > 0), "{sstores:#?}");
+            assert!(sstores[1].state_gas_cost.is_some_and(|cost| cost < 0), "{sstores:#?}");
+            assert!(frame.struct_logs.iter().all(|log| log.state_gas_reservoir.is_some()));
+        } else {
+            assert!(frame
+                .struct_logs
+                .iter()
+                .all(|log| { log.state_gas_cost.is_none() && log.state_gas_reservoir.is_none() }));
+        }
+
+        let value = serde_json::to_value(&frame).unwrap();
+        assert_eq!(value.get("regularGasUsed").is_some(), enabled);
+        assert_eq!(value.get("stateGasUsed").is_some(), enabled);
+        assert_eq!(value.get("gasRefund").is_some(), enabled);
+        if enabled {
+            let sstore_logs = value["structLogs"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|log| log["op"] == "SSTORE")
+                .collect::<Vec<_>>();
+            assert!(sstore_logs[0]["stateGasCost"].as_i64().is_some_and(|cost| cost > 0));
+            assert!(sstore_logs[1]["stateGasCost"].as_i64().is_some_and(|cost| cost < 0));
+        }
+
+        let (trace, call_gas) = trace_contract(
+            spec,
+            GethDebugTracingOptions::call_tracer(CallConfig::default()),
+            code.into(),
+        );
+        let GethTrace::CallTracer(frame) = trace else {
+            panic!("Expected call tracer");
+        };
+        assert_eq!(
+            frame.regular_gas_used,
+            enabled.then(|| U256::from(call_gas.block_regular_gas_used()))
+        );
+        assert_eq!(frame.state_gas_used, enabled.then_some(U256::ZERO));
+        assert_eq!(frame.gas_refund, enabled.then(|| U256::from(call_gas.final_refunded())));
+
+        // Empty-code calls do not initialize an interpreter, so the fork must also be captured at
+        // frame entry.
+        let (trace, empty_gas) =
+            trace_contract(spec, GethDebugTracingOptions::default(), Bytes::new());
+        let GethTrace::Default(frame) = trace else {
+            panic!("Expected default tracer");
+        };
+        assert_eq!(frame.regular_gas_used, enabled.then_some(empty_gas.block_regular_gas_used()));
+        assert_eq!(frame.state_gas_used, enabled.then_some(0));
+        assert_eq!(frame.gas_refund, enabled.then_some(empty_gas.final_refunded()));
     }
 }
 
@@ -255,6 +353,7 @@ fn test_geth_mux_tracer() {
             GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::FlatCallTracer),
             Some(GethDebugTracerConfig(serde_json::to_value(flatcall_config).unwrap())),
         ),
+        (GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::StateGasTracer), None),
     ]));
 
     let mut insp = MuxInspector::try_from_config(config.clone()).unwrap();
@@ -277,7 +376,7 @@ fn test_geth_mux_tracer() {
     let frame =
         inspector.try_into_mux_frame(&res, ctx.db_ref(), TransactionInfo::default()).unwrap();
 
-    assert_eq!(frame.0.len(), 4);
+    assert_eq!(frame.0.len(), 5);
     assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
         GethDebugBuiltInTracerType::FourByteTracer
     )));
@@ -289,6 +388,9 @@ fn test_geth_mux_tracer() {
     )));
     assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
         GethDebugBuiltInTracerType::FlatCallTracer
+    )));
+    assert!(frame.0.contains_key(&GethDebugTracerType::BuiltInTracer(
+        GethDebugBuiltInTracerType::StateGasTracer
     )));
 
     let four_byte_frame = frame.0
@@ -344,6 +446,19 @@ fn test_geth_mux_tracer() {
             assert!(traces[5].trace.error.is_none());
         }
         _ => panic!("Expected FlatCallTracer"),
+    }
+
+    let state_gas_frame = frame.0
+        [&GethDebugTracerType::BuiltInTracer(GethDebugBuiltInTracerType::StateGasTracer)]
+        .clone();
+    match state_gas_frame {
+        GethTrace::StateGasTracer(state_gas) => {
+            assert_eq!(state_gas.gas_used, res.result.gas().tx_gas_used());
+            assert_eq!(state_gas.regular_gas_used, res.result.gas().block_regular_gas_used());
+            assert_eq!(state_gas.state_gas_used, res.result.gas().block_state_gas_used());
+            assert_eq!(state_gas.gas_refund, res.result.gas().final_refunded());
+        }
+        _ => panic!("Expected StateGasTracer"),
     }
 }
 

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -156,6 +156,41 @@ fn test_geth_erc7562_tracer() {
 }
 
 #[test]
+fn test_geth_state_gas_tracer() {
+    let caller = address!("1000000000000000000000000000000000000002");
+    let context = Context::mainnet().with_db(CacheDB::<EmptyDB>::default());
+    let mut inspector = DebugInspector::new(GethDebugTracingOptions::state_gas_tracer()).unwrap();
+    let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+
+    let res = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 1000000,
+            kind: TransactTo::Call(Address::ZERO),
+            data: Bytes::default(),
+            nonce: 0,
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(res.result.is_success(), "{res:#?}");
+
+    let (ctx, inspector) = evm.ctx_inspector();
+    let tx_env = ctx.tx().clone();
+    let block_env = ctx.block().clone();
+    let trace = inspector.get_result(None, &tx_env, &block_env, &res, ctx.db_mut()).unwrap();
+
+    match trace {
+        GethTrace::StateGasTracer(frame) => {
+            assert_eq!(frame.gas_used, res.result.gas().tx_gas_used());
+            assert_eq!(frame.regular_gas_used, res.result.gas().block_regular_gas_used());
+            assert_eq!(frame.state_gas_used, res.result.gas().block_state_gas_used());
+            assert_eq!(frame.gas_refund, res.result.gas().final_refunded());
+        }
+        _ => panic!("Expected StateGasTracer"),
+    }
+}
+
+#[test]
 fn test_geth_mux_tracer() {
     /*
     contract LogTracing {


### PR DESCRIPTION
Replaces #475.

Implements the EIP-8037 tracing additions from ethereum/execution-apis#852: two-dimensional gas fields on default and call traces, signed per-opcode state-gas accounting, `stateGasTracer`, and mux tracer support. Fork gating uses the actual execution spec, including Amsterdam transactions with zero net state gas and empty-code calls, while pre-Amsterdam responses and legacy builder behavior remain unchanged.

Upstream support landed in alloy-rs/alloy#4113 and is now consumed from the released `alloy-rpc-types-trace` crate.

Prompted by: @onbjerg