### PR TITLE
glamsterdam devnet-8: bump revm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,16 @@ std = [
 ]
 serde = ["dep:serde", "revm/serde"]
 js-tracer = ["dep:boa_engine", "dep:boa_gc"]
+[patch.crates-io]
+revm = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "0cc8b8a0b38e88864352b218a145dcfd0a54692d" }


### PR DESCRIPTION
Pins revm to [bluealloy/revm@0cc8b8a0b3](https://github.com/bluealloy/revm/commit/0cc8b8a0b38e88864352b218a145dcfd0a54692d), the glamsterdam devnet-8 branch (bluealloy/revm#3850), via a `[patch.crates-io]` section.

Devnet-8 carries the Amsterdam gas repricing (EIP-8038: ACCOUNT_WRITE 9000, COLD_STORAGE_ACCESS 2100, CREATE_ACCESS 12000; EIP-2780: TX_VALUE_COST 6000, create intrinsic 24000). No API changes affect this repo — no source changes were needed.

- `cargo check --workspace`: clean, patch applied (no unused-patch warnings)
- `cargo +nightly clippy --workspace --all-targets --all-features`: clean
- `cargo nextest run --workspace --all-features`: 100/100 passed

Follow-up to the devnet-7 branch (`glamsterdam-devnet-7`), same shape with the rev bumped.