### PR TITLE
fix: normalize access list collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ clippy.lint_groups_priority = "allow"
 
 [dependencies]
 # eth
+alloy-eip2930 = { version = "0.2.4", default-features = false }
 alloy-rpc-types-eth = { version = "2.0", default-features = false }
 alloy-rpc-types-trace = { version = "2.0", default-features = false }
 alloy-sol-types = { version = "1.4", default-features = false }

--- a/src/access_list.rs
+++ b/src/access_list.rs
@@ -1,11 +1,11 @@
 use alloc::collections::BTreeSet;
+use alloy_eip2930::{AccessList, AccessListItem};
 use alloy_primitives::{
     map::{HashMap, HashSet},
     Address, TxKind, B256,
 };
 use revm::context::transaction::AuthorizationTr;
 
-use alloy_rpc_types_eth::{AccessList, AccessListItem};
 use revm::{
     bytecode::opcode,
     context::JournalTr,
@@ -39,7 +39,8 @@ impl AccessListInspector {
     /// Creates a new inspector instance
     ///
     /// The `access_list` is the provided access list from the call request
-    pub fn new(access_list: AccessList) -> Self {
+    pub fn new(mut access_list: AccessList) -> Self {
+        access_list.dedup();
         Self {
             excluded: Default::default(),
             touched_slots: access_list
@@ -73,7 +74,9 @@ impl AccessListInspector {
             address,
             storage_keys: slots.into_iter().collect(),
         });
-        AccessList(items.collect())
+        let mut access_list = AccessList(items.collect());
+        access_list.sort();
+        access_list
     }
 
     /// Returns list of addresses and storage keys used by the transaction. It gives you the list of
@@ -83,7 +86,9 @@ impl AccessListInspector {
             address: *address,
             storage_keys: slots.iter().copied().collect(),
         });
-        AccessList(items.collect())
+        let mut access_list = AccessList(items.collect());
+        access_list.sort();
+        access_list
     }
 
     /// Collects addresses which should be excluded from the access list. Must be called before the
@@ -107,6 +112,8 @@ impl AccessListInspector {
         let auth_addrs = context.tx().authorization_list().flat_map(|a| a.authority());
 
         self.excluded = [from, to].into_iter().chain(precompiles).chain(auth_addrs).collect();
+        // Remove seeded excluded entries; SLOAD/SSTORE can re-add slots accessed during execution.
+        self.touched_slots.retain(|address, _| !self.excluded.contains(address));
     }
 }
 

--- a/tests/it/accesslist.rs
+++ b/tests/it/accesslist.rs
@@ -1,11 +1,45 @@
 //! Accesslist tests
 
-use alloy_primitives::{address, hex};
+use alloy_eip2930::{AccessList, AccessListItem};
+use alloy_primitives::{address, hex, Address, B256};
 use revm::{
     bytecode::Bytecode, context::TxEnv, context_interface::TransactTo, database::CacheDB,
     database_interface::EmptyDB, state::AccountInfo, Context, InspectEvm, MainBuilder, MainContext,
 };
 use revm_inspectors::access_list::AccessListInspector;
+
+#[test]
+fn initial_access_list_is_normalized_and_pruned() {
+    let [caller, callee, lower, higher] = [0x10, 0x20, 0x30, 0x40].map(Address::with_last_byte);
+    let [lower_slot, higher_slot] = [1, 2].map(B256::with_last_byte);
+    let item = |address, storage_keys| AccessListItem { address, storage_keys };
+    let initial = AccessList(vec![
+        item(caller, vec![]),
+        item(higher, vec![higher_slot]),
+        item(callee, vec![lower_slot]),
+        item(higher, vec![lower_slot, lower_slot]),
+        item(Address::with_last_byte(1), vec![]),
+        item(lower, vec![]),
+    ]);
+
+    let context = Context::mainnet().with_db(CacheDB::<EmptyDB>::default());
+    let mut inspector = AccessListInspector::new(initial);
+    let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+    let result = evm
+        .inspect_tx(TxEnv {
+            caller,
+            gas_limit: 100_000,
+            kind: TransactTo::Call(callee),
+            ..Default::default()
+        })
+        .unwrap();
+    assert!(result.result.is_success(), "{result:#?}");
+
+    let expected =
+        AccessList(vec![item(lower, vec![]), item(higher, vec![lower_slot, higher_slot])]);
+    assert_eq!(inspector.access_list(), expected);
+    assert_eq!(inspector.into_access_list(), expected);
+}
 
 #[test]
 fn test_access_list_precompile() {

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -1258,7 +1258,8 @@ fn test_geth_calltracer_logs_delegatecall() {
     // Proxy bytecode: DELEGATECALL(gas=0xFFFF, addr=implementation, 0, 0, 0, 0); STOP
     let proxy_code = {
         let mut code = Vec::new();
-        code.extend_from_slice(&hex!("6000600060006000")); // retSize, retOffset, argsSize, argsOffset
+        code.extend_from_slice(&hex!("6000600060006000")); // retSize, retOffset, argsSize,
+                                                           // argsOffset
         code.push(0x73); // PUSH20
         code.extend_from_slice(implementation.as_slice()); // implementation address
         code.extend_from_slice(&hex!("61FFFF")); // PUSH2 gas


### PR DESCRIPTION
Normalizes seeded access lists with alloy-eip2930's native helpers and removes entries already warmed by execution. This keeps output deterministic and prevents excluded addresses supplied in the seed from leaking into the result.