### PR TITLE
chore: bump revm to 43.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloy-sol-types = { version = "1.4", default-features = false }
 alloy-primitives = { version = "1.4", default-features = false, features = [
     "map",
 ] }
-revm = { version = "42.0.1", default-features = false }
+revm = { version = "43.0.0", default-features = false }
 
 anstyle = { version = "1.0", optional = true }
 colorchoice = "1.0"


### PR DESCRIPTION
## Summary

- replace revm 42.0.1 with the published 43.0.0 release
- pick up the Glamsterdam devnet-8 changes previously tested via git patches on `glamsterdam-devnet-8`

## Tests

- `cargo test --workspace`
- `cargo test --workspace --all-features`
- `RUSTFLAGS=-Dwarnings cargo clippy --workspace --all-targets --all-features`
- `cargo +nightly fmt --all --check`
- `RUSTDOCFLAGS="--cfg docsrs -D warnings" cargo +nightly doc --workspace --all-features --no-deps --document-private-items`
- `cargo +1.94 build --workspace --all-features`
- `cargo check --workspace --no-default-features`