### PR TITLE
fix(access-list): only exclude applicable authorities

### DIFF
--- a/src/access_list.rs
+++ b/src/access_list.rs
@@ -1,7 +1,7 @@
 use alloc::collections::BTreeSet;
 use alloy_primitives::{
     map::{HashMap, HashSet},
-    Address, TxKind, B256,
+    Address, TxKind, B256, U256,
 };
 use revm::context::transaction::AuthorizationTr;
 
@@ -9,7 +9,7 @@ use alloy_rpc_types_eth::{AccessList, AccessListItem};
 use revm::{
     bytecode::opcode,
     context::JournalTr,
-    context_interface::{ContextTr, Transaction},
+    context_interface::{Cfg, ContextTr, Transaction},
     inspector::JournalExt,
     interpreter::{
         interpreter_types::{InputsTr, Jumps},
@@ -104,7 +104,17 @@ impl AccessListInspector {
         let precompiles = context.journal_ref().precompile_addresses().clone();
 
         // 7702 authorities should be excluded because those get loaded anyway
-        let auth_addrs = context.tx().authorization_list().flat_map(|a| a.authority());
+        let chain_id = context.cfg().chain_id();
+        let auth_addrs = context.tx().authorization_list().filter_map(|authorization| {
+            let auth_chain_id = authorization.chain_id();
+            if !auth_chain_id.is_zero() && auth_chain_id != U256::from(chain_id) {
+                return None;
+            }
+            if authorization.nonce() == u64::MAX {
+                return None;
+            }
+            authorization.authority()
+        });
 
         self.excluded = [from, to].into_iter().chain(precompiles).chain(auth_addrs).collect();
     }

--- a/tests/it/accesslist.rs
+++ b/tests/it/accesslist.rs
@@ -1,9 +1,18 @@
 //! Accesslist tests
 
-use alloy_primitives::{address, hex};
+use alloy_primitives::{address, hex, Address, U256};
 use revm::{
-    bytecode::Bytecode, context::TxEnv, context_interface::TransactTo, database::CacheDB,
-    database_interface::EmptyDB, state::AccountInfo, Context, InspectEvm, MainBuilder, MainContext,
+    bytecode::Bytecode,
+    context::{transaction::TransactionType, TxEnv},
+    context_interface::{
+        transaction::{Authorization, RecoveredAuthority, RecoveredAuthorization},
+        TransactTo,
+    },
+    database::CacheDB,
+    database_interface::EmptyDB,
+    primitives::hardfork::SpecId,
+    state::AccountInfo,
+    Context, InspectEvm, MainBuilder, MainContext,
 };
 use revm_inspectors::access_list::AccessListInspector;
 
@@ -47,4 +56,63 @@ fn test_access_list_precompile() {
     let erecover = address!("0x0000000000000000000000000000000000000001");
     assert!(accesslist.excluded().contains(&erecover));
     assert!(accesslist.into_access_list().is_empty());
+}
+
+#[test]
+fn test_access_list_authorization_exclusions() {
+    const CHAIN_ID: u64 = 1;
+
+    let caller = address!("00000000000000000000000000000000000000a0");
+    let target = address!("00000000000000000000000000000000000000b0");
+    let current_chain = address!("00000000000000000000000000000000000000c0");
+    let zero_chain = address!("00000000000000000000000000000000000000d0");
+    let wrong_chain = address!("00000000000000000000000000000000000000e0");
+    let max_nonce = address!("00000000000000000000000000000000000000f0");
+
+    let authorization = |chain_id, nonce, authority| {
+        RecoveredAuthorization::new_unchecked(
+            Authorization { chain_id: U256::from(chain_id), address: Address::ZERO, nonce },
+            authority,
+        )
+    };
+    let authorizations = vec![
+        authorization(CHAIN_ID, 0, RecoveredAuthority::Valid(current_chain)),
+        authorization(0, 0, RecoveredAuthority::Valid(zero_chain)),
+        authorization(CHAIN_ID + 1, 0, RecoveredAuthority::Valid(wrong_chain)),
+        authorization(CHAIN_ID, u64::MAX, RecoveredAuthority::Valid(max_nonce)),
+        authorization(CHAIN_ID, 0, RecoveredAuthority::Invalid),
+    ];
+
+    let inspect = |authorizations: Vec<RecoveredAuthorization>| {
+        let context =
+            Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_cfg_chained(|cfg| {
+                cfg.chain_id = CHAIN_ID;
+                cfg.spec = SpecId::PRAGUE;
+            });
+        let mut inspector = AccessListInspector::default();
+        let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+        let mut tx =
+            TxEnv::builder().caller(caller).gas_limit(1_000_000).kind(TransactTo::Call(target));
+        if !authorizations.is_empty() {
+            tx = tx
+                .tx_type(Some(TransactionType::Eip7702 as u8))
+                .authorization_list_recovered(authorizations);
+        }
+        let result = evm.inspect_tx(tx.build_fill()).unwrap();
+        assert!(result.result.is_success(), "{result:#?}");
+        inspector.excluded().clone()
+    };
+
+    let baseline = inspect(Vec::new());
+    let excluded = inspect(authorizations);
+
+    assert!(excluded.contains(&current_chain));
+    assert!(excluded.contains(&zero_chain));
+    assert!(!excluded.contains(&wrong_chain));
+    assert!(!excluded.contains(&max_nonce));
+
+    let mut expected = baseline;
+    expected.extend([current_chain, zero_chain]);
+    // The unrecoverable authorization has no authority and therefore adds nothing.
+    assert_eq!(excluded, expected);
 }


### PR DESCRIPTION
Mirrors [geth's access-list handling](https://github.com/ethereum/go-ethereum/blob/bbb9119caaefbbf619363493e54cc8362d65188d/internal/ethapi/api.go#L1391-L1399): only exclude EIP-7702 authorities whose chain ID is zero or current, whose nonce is below the uint64 maximum, and whose recovery succeeds.

Skipped authorizations should not suppress accounts that execution never warms.