### PR TITLE
fix: honor opcode trace step limits

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -79,7 +79,7 @@ impl<'a> GethTraceBuilder<'a> {
         while let Some(CallTraceStepStackItem { trace_node, step, call_child_id }) =
             step_stack.pop_back()
         {
-            if opts.limit.is_some_and(|limit| limit != 0 && struct_logs.len() as u64 >= limit) {
+            if opts.limit.is_some_and(|limit| struct_logs.len() as u64 >= limit) {
                 break;
             }
 
@@ -134,7 +134,9 @@ impl<'a> GethTraceBuilder<'a> {
         let main_trace_node = &self.nodes[0];
         let main_trace = &main_trace_node.trace;
 
-        let capacity = opts.limit.filter(|limit| *limit != 0).map_or_else(
+        let opts =
+            GethDefaultTracingOptions { limit: opts.limit.filter(|limit| *limit != 0), ..opts };
+        let capacity = opts.limit.map_or_else(
             || self.trace_step_count(),
             |limit| self.trace_step_count().min(usize::try_from(limit).unwrap_or(usize::MAX)),
         );

--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -79,6 +79,10 @@ impl<'a> GethTraceBuilder<'a> {
         while let Some(CallTraceStepStackItem { trace_node, step, call_child_id }) =
             step_stack.pop_back()
         {
+            if opts.limit.is_some_and(|limit| limit != 0 && struct_logs.len() as u64 >= limit) {
+                break;
+            }
+
             // We increment the depth by one because steps that are part of call at depth N should
             // have depth N + 1. For example, steps inside of a top-level call should
             // have depth 1.
@@ -130,7 +134,11 @@ impl<'a> GethTraceBuilder<'a> {
         let main_trace_node = &self.nodes[0];
         let main_trace = &main_trace_node.trace;
 
-        let mut struct_logs = Vec::with_capacity(self.trace_step_count());
+        let capacity = opts.limit.filter(|limit| *limit != 0).map_or_else(
+            || self.trace_step_count(),
+            |limit| self.trace_step_count().min(usize::try_from(limit).unwrap_or(usize::MAX)),
+        );
+        let mut struct_logs = Vec::with_capacity(capacity);
         let mut storage = HashMap::default();
         self.fill_geth_trace(main_trace_node, &opts, &mut storage, &mut struct_logs);
 

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -6,6 +6,7 @@ use alloy_rpc_types_trace::{
     },
     parity::TraceType,
 };
+use core::num::NonZeroU64;
 use revm::bytecode::opcode::OpCode;
 
 /// 256 bits each marking whether an opcode should be included into steps trace or not.
@@ -60,8 +61,8 @@ pub struct TracingInspectorConfig {
     /// Whether to record every individual opcode level step.
     pub record_steps: bool,
     /// Maximum number of opcode steps to capture across all calls in a transaction.
-    /// `None` or zero means unlimited. Execution continues after capture stops.
-    pub step_limit: Option<u64>,
+    /// `None` means unlimited. Execution continues after capture stops.
+    pub step_limit: Option<NonZeroU64>,
     /// Whether to record individual memory snapshots.
     pub record_memory_snapshots: bool,
     /// Whether to record individual stack snapshots.
@@ -195,7 +196,7 @@ impl TracingInspectorConfig {
     #[inline]
     pub fn from_geth_config(config: &GethDefaultTracingOptions) -> Self {
         Self {
-            step_limit: config.limit,
+            step_limit: config.limit.and_then(NonZeroU64::new),
             record_memory_snapshots: config.enable_memory.unwrap_or_default(),
             record_stack_snapshots: if config.disable_stack.unwrap_or_default() {
                 StackSnapshotType::None
@@ -266,7 +267,7 @@ impl TracingInspectorConfig {
         if other.record_steps {
             self.step_limit = if self.record_steps {
                 match (self.step_limit, other.step_limit) {
-                    (Some(a), Some(b)) if a != 0 && b != 0 => Some(a.max(b)),
+                    (Some(a), Some(b)) => Some(a.max(b)),
                     _ => None,
                 }
             } else {
@@ -467,12 +468,18 @@ mod tests {
             limit: Some(2),
             ..Default::default()
         });
-        let larger = TracingInspectorConfig { step_limit: Some(4), ..limited };
+        let larger = TracingInspectorConfig { step_limit: NonZeroU64::new(4), ..limited };
         for (other, expected) in [
-            (TracingInspectorConfig::none(), Some(2)),
-            (larger, Some(4)),
+            (TracingInspectorConfig::none(), NonZeroU64::new(2)),
+            (larger, NonZeroU64::new(4)),
             (TracingInspectorConfig::default_geth(), None),
-            (TracingInspectorConfig { step_limit: Some(0), ..limited }, None),
+            (
+                TracingInspectorConfig::from_geth_config(&GethDefaultTracingOptions {
+                    limit: Some(0),
+                    ..Default::default()
+                }),
+                None,
+            ),
         ] {
             let mut merged = limited;
             merged.merge(other);

--- a/src/tracing/config.rs
+++ b/src/tracing/config.rs
@@ -59,6 +59,9 @@ impl OpcodeFilter {
 pub struct TracingInspectorConfig {
     /// Whether to record every individual opcode level step.
     pub record_steps: bool,
+    /// Maximum number of opcode steps to capture across all calls in a transaction.
+    /// `None` or zero means unlimited. Execution continues after capture stops.
+    pub step_limit: Option<u64>,
     /// Whether to record individual memory snapshots.
     pub record_memory_snapshots: bool,
     /// Whether to record individual stack snapshots.
@@ -83,6 +86,7 @@ impl TracingInspectorConfig {
     pub const fn all() -> Self {
         Self {
             record_steps: true,
+            step_limit: None,
             record_memory_snapshots: true,
             record_stack_snapshots: StackSnapshotType::All,
             record_state_diff: true,
@@ -98,6 +102,7 @@ impl TracingInspectorConfig {
     pub const fn none() -> Self {
         Self {
             record_steps: false,
+            step_limit: None,
             record_memory_snapshots: false,
             record_stack_snapshots: StackSnapshotType::None,
             record_state_diff: false,
@@ -115,6 +120,7 @@ impl TracingInspectorConfig {
     pub const fn default_parity() -> Self {
         Self {
             record_steps: false,
+            step_limit: None,
             record_memory_snapshots: false,
             record_stack_snapshots: StackSnapshotType::None,
             record_state_diff: false,
@@ -155,6 +161,7 @@ impl TracingInspectorConfig {
     pub const fn default_geth() -> Self {
         Self {
             record_steps: true,
+            step_limit: None,
             record_memory_snapshots: false,
             record_stack_snapshots: StackSnapshotType::Full,
             record_state_diff: true,
@@ -188,6 +195,7 @@ impl TracingInspectorConfig {
     #[inline]
     pub fn from_geth_config(config: &GethDefaultTracingOptions) -> Self {
         Self {
+            step_limit: config.limit,
             record_memory_snapshots: config.enable_memory.unwrap_or_default(),
             record_stack_snapshots: if config.disable_stack.unwrap_or_default() {
                 StackSnapshotType::None
@@ -253,6 +261,18 @@ impl TracingInspectorConfig {
     /// Merge another config into this one.
     #[inline]
     pub fn merge(&mut self, other: Self) -> &mut Self {
+        // Capture enough steps for both consumers. A consumer that does not record steps
+        // must not affect the limit, while an unlimited step consumer takes precedence.
+        if other.record_steps {
+            self.step_limit = if self.record_steps {
+                match (self.step_limit, other.step_limit) {
+                    (Some(a), Some(b)) if a != 0 && b != 0 => Some(a.max(b)),
+                    _ => None,
+                }
+            } else {
+                other.step_limit
+            };
+        }
         self.record_steps |= other.record_steps;
         self.record_memory_snapshots |= other.record_memory_snapshots;
         self.record_stack_snapshots = other.record_stack_snapshots;
@@ -440,6 +460,28 @@ impl TraceStyle {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn merge_step_limits_preserves_each_consumers_capture() {
+        let limited = TracingInspectorConfig::from_geth_config(&GethDefaultTracingOptions {
+            limit: Some(2),
+            ..Default::default()
+        });
+        let larger = TracingInspectorConfig { step_limit: Some(4), ..limited };
+        for (other, expected) in [
+            (TracingInspectorConfig::none(), Some(2)),
+            (larger, Some(4)),
+            (TracingInspectorConfig::default_geth(), None),
+            (TracingInspectorConfig { step_limit: Some(0), ..limited }, None),
+        ] {
+            let mut merged = limited;
+            merged.merge(other);
+            assert_eq!(merged.step_limit, expected);
+            let mut reversed = other;
+            reversed.merge(limited);
+            assert_eq!(reversed.step_limit, expected);
+        }
+    }
 
     #[test]
     fn test_parity_config() {

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -80,6 +80,8 @@ pub struct TracingInspector {
     trace_stack: Vec<usize>,
     /// Tracks whether the next `step_end` should be recorded. Set in `start_step`.
     record_step_end: bool,
+    /// Number of opcode steps captured across all calls since the last reset.
+    recorded_steps: u64,
     /// Tracks the return value of the last call
     last_call_return_data: Option<Bytes>,
     /// Tracks the journal len in the step, used in step_end to check if the journal has changed
@@ -113,6 +115,7 @@ impl TracingInspector {
             last_journal_len,
             spec_id,
             record_step_end,
+            recorded_steps,
             // kept
             config,
             reusable_step_vecs,
@@ -135,6 +138,7 @@ impl TracingInspector {
         spec_id.take();
         *last_journal_len = 0;
         *record_step_end = false;
+        *recorded_steps = 0;
     }
 
     /// Resets the inspector to it's initial state of [Self::new].
@@ -427,12 +431,14 @@ impl TracingInspector {
         // that not a known constant.
         let op = OpCode::new_or_unknown(interp.bytecode.opcode());
 
-        let record = self.config.should_record_opcode(op);
+        let record = self.config.should_record_opcode(op)
+            && self.config.step_limit.is_none_or(|limit| limit == 0 || self.recorded_steps < limit);
         self.record_step_end = record;
         if !record {
             return;
         }
 
+        self.recorded_steps += 1;
         let trace_idx = self.last_trace_idx();
         let node = &mut self.traces.arena[trace_idx];
 

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -432,7 +432,7 @@ impl TracingInspector {
         let op = OpCode::new_or_unknown(interp.bytecode.opcode());
 
         let record = self.config.should_record_opcode(op)
-            && self.config.step_limit.is_none_or(|limit| limit == 0 || self.recorded_steps < limit);
+            && self.config.step_limit.is_none_or(|limit| self.recorded_steps < limit.get());
         self.record_step_end = record;
         if !record {
             return;

--- a/tests/it/geth.rs
+++ b/tests/it/geth.rs
@@ -1183,3 +1183,173 @@ fn test_geth_calltracer_logs_delegatecall() {
         "Log emitter must NOT be the implementation (bytecode) address"
     );
 }
+
+/// Execute real bytecode and compare capped capture with the complete execution.
+#[test]
+fn test_geth_opcode_limit() {
+    let account = address!("1000000000000000000000000000000000000001");
+    let child = address!("00000000000000000000000000000000000000ff");
+    for terminal in [opcode::RETURN, opcode::REVERT, opcode::INVALID] {
+        // Call a child, then return/revert with one byte (0x2a), or halt exceptionally.
+        let mut code = hex!("6000600060006000600060ff61fffff150602a60005360016000").to_vec();
+        code.push(terminal);
+        let run = |inspector: &mut TracingInspector, opts: GethDefaultTracingOptions| {
+            let context =
+                Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+                    for (addr, code) in
+                        [(account, Bytes::from(code.clone())), (child, hex!("60015000").into())]
+                    {
+                        db.insert_account_info(
+                            addr,
+                            AccountInfo {
+                                code: Some(Bytecode::new_raw(code)),
+                                ..Default::default()
+                            },
+                        );
+                    }
+                });
+            let result = context
+                .build_mainnet()
+                .with_inspector(&mut *inspector)
+                .inspect_tx(TxEnv {
+                    kind: TxKind::Call(account),
+                    gas_limit: 200_000,
+                    ..Default::default()
+                })
+                .unwrap()
+                .result;
+            inspector.geth_builder().geth_traces(
+                result.tx_gas_used(),
+                result.output().cloned().unwrap_or_default(),
+                opts,
+            )
+        };
+        let mut unlimited = TracingInspector::new(TracingInspectorConfig::default_geth());
+        let full = run(&mut unlimited, GethDefaultTracingOptions::default());
+        assert!(full.struct_logs.len() > 12);
+        assert_eq!(full.struct_logs[8].depth, 2);
+        assert_eq!(full.struct_logs[11].depth, 1);
+        assert_eq!(full.failed, terminal != opcode::RETURN);
+        assert_eq!(
+            full.return_value,
+            if terminal == opcode::INVALID { Bytes::new() } else { hex!("2a").into() }
+        );
+        // Includes caps before CALL, on CALL, in the child, and after returning to the parent.
+        for limit in [None, Some(0), Some(2), Some(8), Some(9), Some(12), Some(u64::MAX)] {
+            let opts = GethDefaultTracingOptions { limit, ..Default::default() };
+            let expected_len = limit.filter(|n| *n != 0).map_or(full.struct_logs.len(), |n| {
+                full.struct_logs.len().min(usize::try_from(n).unwrap_or(usize::MAX))
+            });
+            let mut expected = full.clone();
+            expected.struct_logs.truncate(expected_len);
+            let mut inspector =
+                TracingInspector::new(TracingInspectorConfig::from_geth_config(&opts));
+            for _ in 0..2 {
+                let actual = run(&mut inspector, opts);
+                assert_eq!(actual, expected, "limit {limit:?}, terminal {terminal}");
+                assert_eq!(
+                    inspector.traces().nodes().iter().map(|n| n.trace.steps.len()).sum::<usize>(),
+                    expected_len
+                );
+                inspector.fuse();
+            }
+            // Builder options also apply to already collected unlimited traces.
+            assert_eq!(
+                unlimited.geth_builder().geth_traces(full.gas, full.return_value.clone(), opts),
+                expected
+            );
+        }
+    }
+}
+
+#[test]
+fn test_geth_opcode_limit_ignores_named_tracers() {
+    for tracer in
+        [GethDebugBuiltInTracerType::CallTracer, GethDebugBuiltInTracerType::Erc7562Tracer]
+    {
+        let opts = GethDebugTracingOptions {
+            tracer: Some(GethDebugTracerType::BuiltInTracer(tracer)),
+            config: GethDefaultTracingOptions { limit: Some(2), ..Default::default() },
+            ..Default::default()
+        };
+        let inspector = DebugInspector::new(opts).unwrap();
+        let config = match &inspector {
+            DebugInspector::CallTracer(inspector, _)
+            | DebugInspector::Erc7562Tracer(inspector, _) => inspector.config(),
+            _ => panic!("unexpected tracer"),
+        };
+        assert_eq!(config.step_limit, None);
+    }
+}
+
+/// Exercise JSON options, tracer dispatch, EVM execution, and serialized trace output together.
+#[test]
+fn test_geth_opcode_limit_end_to_end() {
+    use serde_json::{json, Value};
+
+    let account = address!("1000000000000000000000000000000000000001");
+    let child = address!("00000000000000000000000000000000000000ff");
+    for terminal in [opcode::RETURN, opcode::REVERT] {
+        let run = |options: Value| {
+            let options: GethDebugTracingOptions = serde_json::from_value(options).unwrap();
+            let mut inspector = DebugInspector::new(options).unwrap();
+            // Execute a child call, then write and return/revert with 0x2a after capture stops.
+            let mut code = hex!("6000600060006000600060ff61fffff150602a60005360016000").to_vec();
+            code.push(terminal);
+            let context =
+                Context::mainnet().with_db(CacheDB::<EmptyDB>::default()).modify_db_chained(|db| {
+                    for (addr, code) in
+                        [(account, Bytes::from(code)), (child, hex!("60015000").into())]
+                    {
+                        db.insert_account_info(
+                            addr,
+                            AccountInfo {
+                                code: Some(Bytecode::new_raw(code)),
+                                ..Default::default()
+                            },
+                        );
+                    }
+                });
+            let mut evm = context.build_mainnet().with_inspector(&mut inspector);
+            let result = evm
+                .inspect_tx(TxEnv {
+                    kind: TxKind::Call(account),
+                    gas_limit: 200_000,
+                    ..Default::default()
+                })
+                .unwrap();
+            assert_eq!(result.result.is_success(), terminal == opcode::RETURN);
+            assert_eq!(result.result.output().unwrap(), &Bytes::from_static(&[0x2a]));
+
+            let (ctx, inspector) = evm.ctx_inspector();
+            let tx = ctx.tx().clone();
+            let block = ctx.block().clone();
+            let trace = inspector.get_result(None, &tx, &block, &result, ctx.db_mut()).unwrap();
+            (serde_json::to_value(trace).unwrap(), result.result.tx_gas_used())
+        };
+
+        let (full, gas_used) = run(json!({}));
+        assert_eq!(full["gas"], gas_used);
+        assert_eq!(full["failed"], terminal == opcode::REVERT);
+        assert_eq!(full["returnValue"], "0x2a");
+        let steps = full["structLogs"].as_array().unwrap();
+        assert!(steps.len() > 12);
+        assert_eq!(steps[8]["depth"], 2);
+        assert_eq!(steps[11]["depth"], 1);
+
+        // The cap must count steps across call frames, including a cap inside the child.
+        for limit in [2, 9, 12] {
+            let (limited, limited_gas) = run(json!({ "limit": limit }));
+            let mut expected = full.clone();
+            expected["structLogs"].as_array_mut().unwrap().truncate(limit);
+            assert_eq!(limited, expected);
+            assert_eq!(limited_gas, gas_used);
+        }
+        assert_eq!(run(json!({ "limit": 0 })).0, full);
+
+        // The same JSON option must not truncate named tracer output.
+        let calls = run(json!({ "tracer": "callTracer" })).0;
+        assert_eq!(calls["calls"].as_array().unwrap().len(), 1);
+        assert_eq!(run(json!({ "tracer": "callTracer", "limit": 2 })).0, calls);
+    }
+}


### PR DESCRIPTION
The default opcode logger deserializes `limit` but never applies it, so requests such as `{"limit":2}` return and retain every execution step.

Honor the option during capture with a transaction-wide counter shared across nested calls, reset it when the inspector is reused, and also cap builder output for callers that supply an existing full trace. Execution continues after capture stops, preserving final gas, output, and success/failure. Zero and omitted limits remain unlimited, and named tracers remain unaffected.

Adds bytecode regressions and an end-to-end test through JSON options, `DebugInspector`, nested EVM execution, and serialized output. Implements the opcode limit semantics specified in ethereum/execution-apis#762.

Corresponding evm2 port: https://github.com/alloy-rs/evm2/pull/400.
