### PR TITLE
perf(geth): avoid quadratic call frame rollup

### DIFF
--- a/src/tracing/builder/geth.rs
+++ b/src/tracing/builder/geth.rs
@@ -252,14 +252,14 @@ impl<'a> GethTraceBuilder<'a> {
         // this will roll up the child frames to their parent; this works because `child idx >
         // parent idx`
         loop {
-            let (idx, call) = call_frames.pop().expect("call frames not empty");
+            let (idx, mut call) = call_frames.pop().expect("call frames not empty");
+            // Children are appended in reverse call order because we walk the arena from the
+            // back, and the selfdestruct frame (if any) was pushed first. Reversing once per frame
+            // restores call order and moves the selfdestruct frame last.
+            call.calls.reverse();
             let node = &self.nodes[idx];
             if let Some(parent) = node.parent {
-                let parent_frame = &mut call_frames[parent];
-                // we need to ensure that calls are in order they are called: the last child node is
-                // the last call, but since we walk up the tree, we need to always
-                // insert at position 0
-                parent_frame.1.calls.insert(0, call);
+                call_frames[parent].1.calls.push(call);
             } else {
                 debug_assert!(call_frames.is_empty(), "only one root node has no parent");
                 return call;
@@ -453,9 +453,13 @@ impl<'a> GethTraceBuilder<'a> {
         }
 
         let include_logs = opts.with_log.unwrap_or_default();
-        let call_config = CallConfig { only_top_call: None, with_log: Some(include_logs) };
 
-        let mut top_call = Some(self.geth_call_traces(call_config, gas_used));
+        // only the root frame's own fields are needed, its children are assembled below
+        let mut top_call = {
+            let mut root = self.nodes[0].geth_empty_call_frame(include_logs);
+            root.gas_used = U256::from(gas_used);
+            Some(root)
+        };
 
         let mut frames: Vec<(usize, Erc7562Frame)> = Vec::with_capacity(self.nodes.len());
 
@@ -609,13 +613,13 @@ impl<'a> GethTraceBuilder<'a> {
             ));
         }
 
-        // Assemble tree
+        // Assemble tree, see `geth_call_traces_inner` for the ordering logic
         loop {
-            let (idx, frame) = frames.pop().expect("call frames not empty");
+            let (idx, mut frame) = frames.pop().expect("call frames not empty");
+            frame.calls.reverse();
             let node = &self.nodes[idx];
             if let Some(parent) = node.parent {
-                let parent_frame = &mut frames[parent];
-                parent_frame.1.calls.insert(0, frame);
+                frames[parent].1.calls.push(frame);
             } else {
                 debug_assert!(frames.is_empty(), "only one root node has no parent");
                 return frame;


### PR DESCRIPTION
Child frames were attached to their parent with `insert(0)`, which memmoves the whole `calls` vector for every child, so a frame with many children is quadratic. With 2000 calls under one frame, building the call frames took 18.9ms while executing the same transaction took 1ms. Frames are now appended while walking the arena from the back and reversed once per frame, which restores call order with the selfdestruct frame last, and brings this down to 0.4ms.

The ERC-7562 tracer also built the full call frame tree just to read the root frame's fields, it now builds only the root frame.

TODO: mirror to https://github.com/alloy-rs/evm2 once merged

# PR stack

Review in order:

1. perf(geth): avoid quadratic call frame rollup #489 — this PR
2. perf(geth): propagate log visibility through call frames #494
