### PR TITLE
perf(tracing): cheaper per-call and per-log bookkeeping

### DIFF
--- a/src/tracing/arena.rs
+++ b/src/tracing/arena.rs
@@ -53,14 +53,16 @@ impl CallTraceArena {
         self.nodes().iter().flat_map(|node| [node.trace.address, node.trace.caller].into_iter())
     }
 
-    /// Pushes a new trace into the arena, returning the trace ID
+    /// Pushes a new trace into the arena as a child of `parent`, returning the trace ID
     ///
     /// This appends a new trace to the arena, and also inserts a new entry in the node's parent
     /// node children set if `attach_to_parent` is `true`. E.g. if calls to precompiles should
     /// not be included in the call graph this should be called with [PushTraceKind::PushOnly].
+    ///
+    /// If the new trace is the root call (depth 0), it replaces the root node instead.
     pub(crate) fn push_trace(
         &mut self,
-        mut entry: usize,
+        parent: usize,
         kind: PushTraceKind,
         new_trace: CallTrace,
     ) -> usize {
@@ -70,14 +72,15 @@ impl CallTraceArena {
             return 0;
         }
 
-        // Otherwise, we need to find the parent node and add the new trace as a child.
-        while self.arena[entry].trace.depth != new_trace.depth - 1 {
-            entry = *self.arena[entry].children.last().expect("Disconnected trace");
-        }
+        debug_assert_eq!(
+            self.arena[parent].trace.depth + 1,
+            new_trace.depth,
+            "parent must be exactly one level above the new trace"
+        );
 
         let idx = self.arena.len();
         self.arena.push(CallTraceNode {
-            parent: Some(entry),
+            parent: Some(parent),
             trace: new_trace,
             idx,
             ..Default::default()
@@ -85,7 +88,7 @@ impl CallTraceArena {
 
         // Also track the child in the parent node.
         if kind.is_attach_to_parent() {
-            let parent = &mut self.arena[entry];
+            let parent = &mut self.arena[parent];
             let trace_location = parent.children.len();
             parent.ordering.push(TraceMemberOrder::Call(trace_location));
             parent.children.push(idx);

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -80,8 +80,8 @@ pub struct TracingInspector {
     trace_stack: Vec<usize>,
     /// Tracks whether the next `step_end` should be recorded. Set in `start_step`.
     record_step_end: bool,
-    /// Tracks the return value of the last call
-    last_call_return_data: Option<Bytes>,
+    /// Number of logs recorded so far, used as the index of the next log.
+    log_count: usize,
     /// Tracks the journal len in the step, used in step_end to check if the journal has changed
     last_journal_len: usize,
     /// The spec id of the EVM.
@@ -109,7 +109,7 @@ impl TracingInspector {
         let Self {
             traces,
             trace_stack,
-            last_call_return_data,
+            log_count,
             last_journal_len,
             spec_id,
             record_step_end,
@@ -131,8 +131,8 @@ impl TracingInspector {
 
         traces.clear();
         trace_stack.clear();
-        last_call_return_data.take();
         spec_id.take();
+        *log_count = 0;
         *last_journal_len = 0;
         *record_step_end = false;
     }
@@ -277,11 +277,6 @@ impl TracingInspector {
         !self.trace_stack.is_empty()
     }
 
-    /// Returns how many logs we already recorded.
-    fn log_count(&self) -> usize {
-        self.traces.nodes().iter().map(|trace| trace.log_count()).sum()
-    }
-
     /// Returns true if this a call to a precompile contract.
     ///
     /// Returns true if the `to` address is a precompile contract and the value is zero.
@@ -366,8 +361,11 @@ impl TracingInspector {
         // find an empty steps vec or create a new one
         let steps = self.reusable_step_vecs.pop().unwrap_or_default();
 
+        // the currently active call is the parent of the new call
+        let parent = self.trace_stack.last().copied().unwrap_or_default();
+
         self.trace_stack.push(self.traces.push_trace(
-            0,
+            parent,
             push_kind,
             CallTrace {
                 depth: context.journal().depth(),
@@ -408,8 +406,6 @@ impl TracingInspector {
         trace.status = Some(result);
         trace.success = trace.status.is_some_and(|status| status.is_ok());
         trace.output = output.clone();
-
-        self.last_call_return_data = Some(output.clone());
 
         if let Some(address) = created_address {
             // A new contract was created via CREATE
@@ -643,7 +639,8 @@ where
     fn log(&mut self, _context: &mut CTX, log: Log) {
         if self.config.record_logs {
             // index starts at 0
-            let log_count = self.log_count();
+            let log_count = self.log_count;
+            self.log_count += 1;
             let trace = self.last_trace();
             trace.ordering.push(TraceMemberOrder::Log(trace.logs.len()));
             trace.logs.push(

--- a/src/tracing/types.rs
+++ b/src/tracing/types.rs
@@ -297,12 +297,6 @@ impl CallTraceNode {
         }
     }
 
-    /// Returns how many logs this trace already has.
-    #[inline]
-    pub(crate) fn log_count(&self) -> usize {
-        self.logs.len()
-    }
-
     /// Returns true if this is a call to a precompile
     #[inline]
     pub fn is_precompile(&self) -> bool {


### PR DESCRIPTION
The log index was computed by summing the log count of every arena node on each recorded log, making log recording quadratic in the number of calls. It is now a running counter that `fuse` resets. For a transaction with 2000 calls that each emit a log, execution with the call tracer (`withLog`) went from 2.3ms to 1ms.

New traces are attached to the active call directly instead of walking down from the root to find the node one level above, and `last_call_return_data`, which was written on every call end but never read, is removed.

TODO: mirror to https://github.com/alloy-rs/evm2 once merged